### PR TITLE
refactor(deploy): Unify server for single deployment

### DIFF
--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -29,13 +29,11 @@ if (process.platform === `win32`) {
     }
   };
 }
-const contains = function(pathUtils, from, to) {
+const contains = function (pathUtils, from, to) {
   from = pathUtils.normalize(from);
   to = pathUtils.normalize(to);
-  if (from === to)
-    return `.`;
-  if (!from.endsWith(pathUtils.sep))
-    from = from + pathUtils.sep;
+  if (from === to) return `.`;
+  if (!from.endsWith(pathUtils.sep)) from = from + pathUtils.sep;
   if (to.startsWith(from)) {
     return to.slice(from.length);
   } else {
@@ -50,20 +48,17 @@ const PORTABLE_PATH_REGEXP = /^\/([a-zA-Z]:.*)$/;
 const UNC_PORTABLE_PATH_REGEXP = /^\/unc\/(\.dot\/)?(.*)$/;
 function fromPortablePathWin32(p) {
   let portablePathMatch, uncPortablePathMatch;
-  if (portablePathMatch = p.match(PORTABLE_PATH_REGEXP))
-    p = portablePathMatch[1];
-  else if (uncPortablePathMatch = p.match(UNC_PORTABLE_PATH_REGEXP))
+  if ((portablePathMatch = p.match(PORTABLE_PATH_REGEXP))) p = portablePathMatch[1];
+  else if ((uncPortablePathMatch = p.match(UNC_PORTABLE_PATH_REGEXP)))
     p = `\\\\${uncPortablePathMatch[1] ? `.\\` : ``}${uncPortablePathMatch[2]}`;
-  else
-    return p;
+  else return p;
   return p.replace(/\//g, `\\`);
 }
 function toPortablePathWin32(p) {
   p = p.replace(/\\/g, `/`);
   let windowsPathMatch, uncWindowsPathMatch;
-  if (windowsPathMatch = p.match(WINDOWS_PATH_REGEXP))
-    p = `/${windowsPathMatch[1]}`;
-  else if (uncWindowsPathMatch = p.match(UNC_WINDOWS_PATH_REGEXP))
+  if ((windowsPathMatch = p.match(WINDOWS_PATH_REGEXP))) p = `/${windowsPathMatch[1]}`;
+  else if ((uncWindowsPathMatch = p.match(UNC_WINDOWS_PATH_REGEXP)))
     p = `/unc/${uncWindowsPathMatch[1] ? `.dot/` : ``}${uncWindowsPathMatch[2]}`;
   return p;
 }
@@ -82,34 +77,79 @@ async function copyPromise(destinationFs, destination, sourceFs, source, opts) {
   const normalizedSource = sourceFs.pathUtils.normalize(source);
   const prelayout = [];
   const postlayout = [];
-  const { atime, mtime } = opts.stableTime ? { atime: defaultTime, mtime: defaultTime } : await sourceFs.lstatPromise(normalizedSource);
-  await destinationFs.mkdirpPromise(destinationFs.pathUtils.dirname(destination), { utimes: [atime, mtime] });
-  await copyImpl(prelayout, postlayout, destinationFs, normalizedDestination, sourceFs, normalizedSource, { ...opts, didParentExist: true });
-  for (const operation of prelayout)
-    await operation();
-  await Promise.all(postlayout.map((operation) => {
-    return operation();
-  }));
+  const { atime, mtime } = opts.stableTime
+    ? { atime: defaultTime, mtime: defaultTime }
+    : await sourceFs.lstatPromise(normalizedSource);
+  await destinationFs.mkdirpPromise(destinationFs.pathUtils.dirname(destination), {
+    utimes: [atime, mtime]
+  });
+  await copyImpl(
+    prelayout,
+    postlayout,
+    destinationFs,
+    normalizedDestination,
+    sourceFs,
+    normalizedSource,
+    { ...opts, didParentExist: true }
+  );
+  for (const operation of prelayout) await operation();
+  await Promise.all(
+    postlayout.map((operation) => {
+      return operation();
+    })
+  );
 }
 async function copyImpl(prelayout, postlayout, destinationFs, destination, sourceFs, source, opts) {
   const destinationStat = opts.didParentExist ? await maybeLStat(destinationFs, destination) : null;
   const sourceStat = await sourceFs.lstatPromise(source);
-  const { atime, mtime } = opts.stableTime ? { atime: defaultTime, mtime: defaultTime } : sourceStat;
+  const { atime, mtime } = opts.stableTime
+    ? { atime: defaultTime, mtime: defaultTime }
+    : sourceStat;
   let updated;
   switch (true) {
     case sourceStat.isDirectory():
       {
-        updated = await copyFolder(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+        updated = await copyFolder(
+          prelayout,
+          postlayout,
+          destinationFs,
+          destination,
+          destinationStat,
+          sourceFs,
+          source,
+          sourceStat,
+          opts
+        );
       }
       break;
     case sourceStat.isFile():
       {
-        updated = await copyFile(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+        updated = await copyFile(
+          prelayout,
+          postlayout,
+          destinationFs,
+          destination,
+          destinationStat,
+          sourceFs,
+          source,
+          sourceStat,
+          opts
+        );
       }
       break;
     case sourceStat.isSymbolicLink():
       {
-        updated = await copySymlink(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+        updated = await copySymlink(
+          prelayout,
+          postlayout,
+          destinationFs,
+          destination,
+          destinationStat,
+          sourceFs,
+          source,
+          sourceStat,
+          opts
+        );
       }
       break;
     default: {
@@ -117,7 +157,11 @@ async function copyImpl(prelayout, postlayout, destinationFs, destination, sourc
     }
   }
   if (opts.linkStrategy?.type !== `HardlinkFromIndex` || !sourceStat.isFile()) {
-    if (updated || destinationStat?.mtime?.getTime() !== mtime.getTime() || destinationStat?.atime?.getTime() !== atime.getTime()) {
+    if (
+      updated ||
+      destinationStat?.mtime?.getTime() !== mtime.getTime() ||
+      destinationStat?.atime?.getTime() !== atime.getTime()
+    ) {
       postlayout.push(() => destinationFs.lutimesPromise(destination, atime, mtime));
       updated = true;
     }
@@ -135,7 +179,17 @@ async function maybeLStat(baseFs, p) {
     return null;
   }
 }
-async function copyFolder(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts) {
+async function copyFolder(
+  prelayout,
+  postlayout,
+  destinationFs,
+  destination,
+  destinationStat,
+  sourceFs,
+  source,
+  sourceStat,
+  opts
+) {
   if (destinationStat !== null && !destinationStat.isDirectory()) {
     if (opts.overwrite) {
       prelayout.push(async () => destinationFs.removePromise(destination));
@@ -158,38 +212,75 @@ async function copyFolder(prelayout, postlayout, destinationFs, destination, des
     updated = true;
   }
   const entries = await sourceFs.readdirPromise(source);
-  const nextOpts = opts.didParentExist && !destinationStat ? { ...opts, didParentExist: false } : opts;
+  const nextOpts =
+    opts.didParentExist && !destinationStat ? { ...opts, didParentExist: false } : opts;
   if (opts.stableSort) {
     for (const entry of entries.sort()) {
-      if (await copyImpl(prelayout, postlayout, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), nextOpts)) {
+      if (
+        await copyImpl(
+          prelayout,
+          postlayout,
+          destinationFs,
+          destinationFs.pathUtils.join(destination, entry),
+          sourceFs,
+          sourceFs.pathUtils.join(source, entry),
+          nextOpts
+        )
+      ) {
         updated = true;
       }
     }
   } else {
-    const entriesUpdateStatus = await Promise.all(entries.map(async (entry) => {
-      await copyImpl(prelayout, postlayout, destinationFs, destinationFs.pathUtils.join(destination, entry), sourceFs, sourceFs.pathUtils.join(source, entry), nextOpts);
-    }));
+    const entriesUpdateStatus = await Promise.all(
+      entries.map(async (entry) => {
+        await copyImpl(
+          prelayout,
+          postlayout,
+          destinationFs,
+          destinationFs.pathUtils.join(destination, entry),
+          sourceFs,
+          sourceFs.pathUtils.join(source, entry),
+          nextOpts
+        );
+      })
+    );
     if (entriesUpdateStatus.some((status) => status)) {
       updated = true;
     }
   }
   return updated;
 }
-async function copyFileViaIndex(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts, linkStrategy) {
+async function copyFileViaIndex(
+  prelayout,
+  postlayout,
+  destinationFs,
+  destination,
+  destinationStat,
+  sourceFs,
+  source,
+  sourceStat,
+  opts,
+  linkStrategy
+) {
   const sourceHash = await sourceFs.checksumFilePromise(source, { algorithm: `sha1` });
   const defaultMode = 420;
   const sourceMode = sourceStat.mode & 511;
   const indexFileName = `${sourceHash}${sourceMode !== defaultMode ? sourceMode.toString(8) : ``}`;
-  const indexPath = destinationFs.pathUtils.join(linkStrategy.indexPath, sourceHash.slice(0, 2), `${indexFileName}.dat`);
+  const indexPath = destinationFs.pathUtils.join(
+    linkStrategy.indexPath,
+    sourceHash.slice(0, 2),
+    `${indexFileName}.dat`
+  );
   let AtomicBehavior;
   ((AtomicBehavior2) => {
-    AtomicBehavior2[AtomicBehavior2["Lock"] = 0] = "Lock";
-    AtomicBehavior2[AtomicBehavior2["Rename"] = 1] = "Rename";
+    AtomicBehavior2[(AtomicBehavior2['Lock'] = 0)] = 'Lock';
+    AtomicBehavior2[(AtomicBehavior2['Rename'] = 1)] = 'Rename';
   })(AtomicBehavior || (AtomicBehavior = {}));
-  let atomicBehavior = 1 /* Rename */;
+  let atomicBehavior = 1; /* Rename */
   let indexStat = await maybeLStat(destinationFs, indexPath);
   if (destinationStat) {
-    const isDestinationHardlinkedFromIndex = indexStat && destinationStat.dev === indexStat.dev && destinationStat.ino === indexStat.ino;
+    const isDestinationHardlinkedFromIndex =
+      indexStat && destinationStat.dev === indexStat.dev && destinationStat.ino === indexStat.ino;
     const isIndexModified = indexStat?.mtimeMs !== defaultTimeMs;
     if (isDestinationHardlinkedFromIndex) {
       if (isIndexModified && linkStrategy.autoRepair) {
@@ -206,7 +297,12 @@ async function copyFileViaIndex(prelayout, postlayout, destinationFs, destinatio
       }
     }
   }
-  const tempPath = !indexStat && atomicBehavior === 1 /* Rename */ ? `${indexPath}.${Math.floor(Math.random() * 4294967296).toString(16).padStart(8, `0`)}` : null;
+  const tempPath =
+    !indexStat && atomicBehavior === 1 /* Rename */
+      ? `${indexPath}.${Math.floor(Math.random() * 4294967296)
+          .toString(16)
+          .padStart(8, `0`)}`
+      : null;
   let tempPathCleaned = false;
   prelayout.push(async () => {
     if (!indexStat) {
@@ -248,7 +344,17 @@ async function copyFileViaIndex(prelayout, postlayout, destinationFs, destinatio
   });
   return false;
 }
-async function copyFileDirect(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts) {
+async function copyFileDirect(
+  prelayout,
+  postlayout,
+  destinationFs,
+  destination,
+  destinationStat,
+  sourceFs,
+  source,
+  sourceStat,
+  opts
+) {
   if (destinationStat !== null) {
     if (opts.overwrite) {
       prelayout.push(async () => destinationFs.removePromise(destination));
@@ -263,14 +369,55 @@ async function copyFileDirect(prelayout, postlayout, destinationFs, destination,
   });
   return true;
 }
-async function copyFile(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts) {
+async function copyFile(
+  prelayout,
+  postlayout,
+  destinationFs,
+  destination,
+  destinationStat,
+  sourceFs,
+  source,
+  sourceStat,
+  opts
+) {
   if (opts.linkStrategy?.type === `HardlinkFromIndex`) {
-    return copyFileViaIndex(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts, opts.linkStrategy);
+    return copyFileViaIndex(
+      prelayout,
+      postlayout,
+      destinationFs,
+      destination,
+      destinationStat,
+      sourceFs,
+      source,
+      sourceStat,
+      opts,
+      opts.linkStrategy
+    );
   } else {
-    return copyFileDirect(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts);
+    return copyFileDirect(
+      prelayout,
+      postlayout,
+      destinationFs,
+      destination,
+      destinationStat,
+      sourceFs,
+      source,
+      sourceStat,
+      opts
+    );
   }
 }
-async function copySymlink(prelayout, postlayout, destinationFs, destination, destinationStat, sourceFs, source, sourceStat, opts) {
+async function copySymlink(
+  prelayout,
+  postlayout,
+  destinationFs,
+  destination,
+  destinationStat,
+  sourceFs,
+  source,
+  sourceStat,
+  opts
+) {
   if (destinationStat !== null) {
     if (opts.overwrite) {
       prelayout.push(async () => destinationFs.removePromise(destination));
@@ -280,7 +427,10 @@ async function copySymlink(prelayout, postlayout, destinationFs, destination, de
     }
   }
   prelayout.push(async () => {
-    await destinationFs.symlinkPromise(convertPath(destinationFs.pathUtils, await sourceFs.readlinkPromise(source)), destination);
+    await destinationFs.symlinkPromise(
+      convertPath(destinationFs.pathUtils, await sourceFs.readlinkPromise(source)),
+      destination
+    );
   });
   return true;
 }
@@ -337,9 +487,11 @@ class FakeFS {
     if (stat.isDirectory()) {
       if (recursive) {
         const entries = await this.readdirPromise(p);
-        await Promise.all(entries.map((entry) => {
-          return this.removePromise(this.pathUtils.resolve(p, entry));
-        }));
+        await Promise.all(
+          entries.map((entry) => {
+            return this.removePromise(this.pathUtils.resolve(p, entry));
+          })
+        );
       }
       for (let t = 0; t <= maxRetries; t++) {
         try {
@@ -370,8 +522,7 @@ class FakeFS {
     }
     if (stat.isDirectory()) {
       if (recursive)
-        for (const entry of this.readdirSync(p))
-          this.removeSync(this.pathUtils.resolve(p, entry));
+        for (const entry of this.readdirSync(p)) this.removeSync(this.pathUtils.resolve(p, entry));
       this.rmdirSync(p);
     } else {
       this.unlinkSync(p);
@@ -379,8 +530,7 @@ class FakeFS {
   }
   async mkdirpPromise(p, { chmod, utimes } = {}) {
     p = this.resolve(p);
-    if (p === this.pathUtils.dirname(p))
-      return void 0;
+    if (p === this.pathUtils.dirname(p)) return void 0;
     const parts = p.split(this.pathUtils.sep);
     let createdDirectory;
     for (let u = 2; u <= parts.length; ++u) {
@@ -396,8 +546,7 @@ class FakeFS {
           }
         }
         createdDirectory ??= subPath;
-        if (chmod != null)
-          await this.chmodPromise(subPath, chmod);
+        if (chmod != null) await this.chmodPromise(subPath, chmod);
         if (utimes != null) {
           await this.utimesPromise(subPath, utimes[0], utimes[1]);
         } else {
@@ -410,8 +559,7 @@ class FakeFS {
   }
   mkdirpSync(p, { chmod, utimes } = {}) {
     p = this.resolve(p);
-    if (p === this.pathUtils.dirname(p))
-      return void 0;
+    if (p === this.pathUtils.dirname(p)) return void 0;
     const parts = p.split(this.pathUtils.sep);
     let createdDirectory;
     for (let u = 2; u <= parts.length; ++u) {
@@ -427,8 +575,7 @@ class FakeFS {
           }
         }
         createdDirectory ??= subPath;
-        if (chmod != null)
-          this.chmodSync(subPath, chmod);
+        if (chmod != null) this.chmodSync(subPath, chmod);
         if (utimes != null) {
           this.utimesSync(subPath, utimes[0], utimes[1]);
         } else {
@@ -439,8 +586,23 @@ class FakeFS {
     }
     return createdDirectory;
   }
-  async copyPromise(destination, source, { baseFs = this, overwrite = true, stableSort = false, stableTime = false, linkStrategy = null } = {}) {
-    return await copyPromise(this, destination, baseFs, source, { overwrite, stableSort, stableTime, linkStrategy });
+  async copyPromise(
+    destination,
+    source,
+    {
+      baseFs = this,
+      overwrite = true,
+      stableSort = false,
+      stableTime = false,
+      linkStrategy = null
+    } = {}
+  ) {
+    return await copyPromise(this, destination, baseFs, source, {
+      overwrite,
+      stableSort,
+      stableTime,
+      linkStrategy
+    });
   }
   copySync(destination, source, { baseFs = this, overwrite = true } = {}) {
     const stat = baseFs.lstatSync(source);
@@ -449,24 +611,28 @@ class FakeFS {
       this.mkdirpSync(destination);
       const directoryListing = baseFs.readdirSync(source);
       for (const entry of directoryListing) {
-        this.copySync(this.pathUtils.join(destination, entry), baseFs.pathUtils.join(source, entry), { baseFs, overwrite });
+        this.copySync(
+          this.pathUtils.join(destination, entry),
+          baseFs.pathUtils.join(source, entry),
+          { baseFs, overwrite }
+        );
       }
     } else if (stat.isFile()) {
       if (!exists || overwrite) {
-        if (exists)
-          this.removeSync(destination);
+        if (exists) this.removeSync(destination);
         const content = baseFs.readFileSync(source);
         this.writeFileSync(destination, content);
       }
     } else if (stat.isSymbolicLink()) {
       if (!exists || overwrite) {
-        if (exists)
-          this.removeSync(destination);
+        if (exists) this.removeSync(destination);
         const target = baseFs.readlinkSync(source);
         this.symlinkSync(convertPath(this.pathUtils, target), destination);
       }
     } else {
-      throw new Error(`Unsupported file type (file: ${source}, mode: 0o${stat.mode.toString(8).padStart(6, `0`)})`);
+      throw new Error(
+        `Unsupported file type (file: ${source}, mode: 0o${stat.mode.toString(8).padStart(6, `0`)})`
+      );
     }
     const mode = stat.mode & 511;
     this.chmodSync(destination, mode);
@@ -482,21 +648,17 @@ class FakeFS {
     let current = Buffer.alloc(0);
     try {
       current = await this.readFilePromise(p);
-    } catch (error) {
-    }
-    if (Buffer.compare(current, content) === 0)
-      return;
+    } catch (error) {}
+    if (Buffer.compare(current, content) === 0) return;
     await this.writeFilePromise(p, content, { mode });
   }
   async changeFileTextPromise(p, content, { automaticNewlines, mode } = {}) {
     let current = ``;
     try {
       current = await this.readFilePromise(p, `utf8`);
-    } catch (error) {
-    }
+    } catch (error) {}
     const normalizedContent = automaticNewlines ? normalizeLineEndings(current, content) : content;
-    if (current === normalizedContent)
-      return;
+    if (current === normalizedContent) return;
     await this.writeFilePromise(p, normalizedContent, { mode });
   }
   changeFileSync(p, content, opts = {}) {
@@ -510,21 +672,17 @@ class FakeFS {
     let current = Buffer.alloc(0);
     try {
       current = this.readFileSync(p);
-    } catch (error) {
-    }
-    if (Buffer.compare(current, content) === 0)
-      return;
+    } catch (error) {}
+    if (Buffer.compare(current, content) === 0) return;
     this.writeFileSync(p, content, { mode });
   }
   changeFileTextSync(p, content, { automaticNewlines = false, mode } = {}) {
     let current = ``;
     try {
       current = this.readFileSync(p, `utf8`);
-    } catch (error) {
-    }
+    } catch (error) {}
     const normalizedContent = automaticNewlines ? normalizeLineEndings(current, content) : content;
-    if (current === normalizedContent)
-      return;
+    if (current === normalizedContent) return;
     this.writeFileSync(p, normalizedContent, { mode });
   }
   async movePromise(fromP, toP) {
@@ -575,12 +733,11 @@ class FakeFS {
         fd = await this.openPromise(lockPath, `wx`);
       } catch (error) {
         if (error.code === `EEXIST`) {
-          if (!await isAlive()) {
+          if (!(await isAlive())) {
             try {
               await this.unlinkPromise(lockPath);
               continue;
-            } catch (error2) {
-            }
+            } catch (error2) {}
           }
           if (Date.now() - startTime < 60 * 1e3) {
             await new Promise((resolve) => setTimeout(resolve, interval));
@@ -599,8 +756,7 @@ class FakeFS {
       try {
         await this.closePromise(fd);
         await this.unlinkPromise(lockPath);
-      } catch (error) {
-      }
+      } catch (error) {}
     }
   }
   async readJsonPromise(p) {
@@ -623,26 +779,30 @@ class FakeFS {
   }
   async writeJsonPromise(p, data, { compact = false } = {}) {
     const space = compact ? 0 : 2;
-    return await this.writeFilePromise(p, `${JSON.stringify(data, null, space)}
-`);
+    return await this.writeFilePromise(
+      p,
+      `${JSON.stringify(data, null, space)}
+`
+    );
   }
   writeJsonSync(p, data, { compact = false } = {}) {
     const space = compact ? 0 : 2;
-    return this.writeFileSync(p, `${JSON.stringify(data, null, space)}
-`);
+    return this.writeFileSync(
+      p,
+      `${JSON.stringify(data, null, space)}
+`
+    );
   }
   async preserveTimePromise(p, cb) {
     const stat = await this.lstatPromise(p);
     const result = await cb();
-    if (typeof result !== `undefined`)
-      p = result;
+    if (typeof result !== `undefined`) p = result;
     await this.lutimesPromise(p, stat.atime, stat.mtime);
   }
   async preserveTimeSync(p, cb) {
     const stat = this.lstatSync(p);
     const result = cb();
-    if (typeof result !== `undefined`)
-      p = result;
+    if (typeof result !== `undefined`) p = result;
     this.lutimesSync(p, stat.atime, stat.mtime);
   }
 }
@@ -653,13 +813,18 @@ class BasePortableFakeFS extends FakeFS {
 }
 function getEndOfLine(content) {
   const matches = content.match(/\r?\n/g);
-  if (matches === null)
-    return EOL;
-  const crlf = matches.filter((nl) => nl === `\r
-`).length;
+  if (matches === null) return EOL;
+  const crlf = matches.filter(
+    (nl) =>
+      nl ===
+      `\r
+`
+  ).length;
   const lf = matches.length - crlf;
-  return crlf > lf ? `\r
-` : `
+  return crlf > lf
+    ? `\r
+`
+    : `
 `;
 }
 function normalizeLineEndings(originalContent, newContent) {
@@ -850,16 +1015,26 @@ class ProxiedFS extends FakeFS {
     const mappedP = this.mapToBase(p);
     if (this.pathUtils.isAbsolute(target))
       return this.baseFs.symlinkPromise(this.mapToBase(target), mappedP, type);
-    const mappedAbsoluteTarget = this.mapToBase(this.pathUtils.join(this.pathUtils.dirname(p), target));
-    const mappedTarget = this.baseFs.pathUtils.relative(this.baseFs.pathUtils.dirname(mappedP), mappedAbsoluteTarget);
+    const mappedAbsoluteTarget = this.mapToBase(
+      this.pathUtils.join(this.pathUtils.dirname(p), target)
+    );
+    const mappedTarget = this.baseFs.pathUtils.relative(
+      this.baseFs.pathUtils.dirname(mappedP),
+      mappedAbsoluteTarget
+    );
     return this.baseFs.symlinkPromise(mappedTarget, mappedP, type);
   }
   symlinkSync(target, p, type) {
     const mappedP = this.mapToBase(p);
     if (this.pathUtils.isAbsolute(target))
       return this.baseFs.symlinkSync(this.mapToBase(target), mappedP, type);
-    const mappedAbsoluteTarget = this.mapToBase(this.pathUtils.join(this.pathUtils.dirname(p), target));
-    const mappedTarget = this.baseFs.pathUtils.relative(this.baseFs.pathUtils.dirname(mappedP), mappedAbsoluteTarget);
+    const mappedAbsoluteTarget = this.mapToBase(
+      this.pathUtils.join(this.pathUtils.dirname(p), target)
+    );
+    const mappedTarget = this.baseFs.pathUtils.relative(
+      this.baseFs.pathUtils.dirname(mappedP),
+      mappedAbsoluteTarget
+    );
     return this.baseFs.symlinkSync(mappedTarget, mappedP, type);
   }
   async readFilePromise(p, encoding) {
@@ -922,8 +1097,7 @@ class ProxiedFS extends FakeFS {
 
 function direntToPortable(dirent) {
   const portableDirent = dirent;
-  if (typeof dirent.path === `string`)
-    portableDirent.path = npath.toPortablePath(dirent.path);
+  if (typeof dirent.path === `string`) portableDirent.path = npath.toPortablePath(dirent.path);
   return portableDirent;
 }
 class NodeFS extends BasePortableFakeFS {
@@ -967,7 +1141,10 @@ class NodeFS extends BasePortableFakeFS {
     });
   }
   opendirSync(p, opts) {
-    const dir = typeof opts !== `undefined` ? this.realFs.opendirSync(npath.fromPortablePath(p), opts) : this.realFs.opendirSync(npath.fromPortablePath(p));
+    const dir =
+      typeof opts !== `undefined`
+        ? this.realFs.opendirSync(npath.fromPortablePath(p), opts)
+        : this.realFs.opendirSync(npath.fromPortablePath(p));
     const dirWithFixedPath = dir;
     Object.defineProperty(dirWithFixedPath, `path`, {
       value: p,
@@ -995,7 +1172,14 @@ class NodeFS extends BasePortableFakeFS {
       if (typeof buffer === `string`) {
         return this.realFs.write(fd, buffer, offset, this.makeCallback(resolve, reject));
       } else {
-        return this.realFs.write(fd, buffer, offset, length, position, this.makeCallback(resolve, reject));
+        return this.realFs.write(
+          fd,
+          buffer,
+          offset,
+          length,
+          position,
+          this.makeCallback(resolve, reject)
+        );
       }
     });
   }
@@ -1130,7 +1314,11 @@ class NodeFS extends BasePortableFakeFS {
   }
   async renamePromise(oldP, newP) {
     return await new Promise((resolve, reject) => {
-      this.realFs.rename(npath.fromPortablePath(oldP), npath.fromPortablePath(newP), this.makeCallback(resolve, reject));
+      this.realFs.rename(
+        npath.fromPortablePath(oldP),
+        npath.fromPortablePath(newP),
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   renameSync(oldP, newP) {
@@ -1138,11 +1326,20 @@ class NodeFS extends BasePortableFakeFS {
   }
   async copyFilePromise(sourceP, destP, flags = 0) {
     return await new Promise((resolve, reject) => {
-      this.realFs.copyFile(npath.fromPortablePath(sourceP), npath.fromPortablePath(destP), flags, this.makeCallback(resolve, reject));
+      this.realFs.copyFile(
+        npath.fromPortablePath(sourceP),
+        npath.fromPortablePath(destP),
+        flags,
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   copyFileSync(sourceP, destP, flags = 0) {
-    return this.realFs.copyFileSync(npath.fromPortablePath(sourceP), npath.fromPortablePath(destP), flags);
+    return this.realFs.copyFileSync(
+      npath.fromPortablePath(sourceP),
+      npath.fromPortablePath(destP),
+      flags
+    );
   }
   async appendFilePromise(p, content, opts) {
     return await new Promise((resolve, reject) => {
@@ -1190,7 +1387,12 @@ class NodeFS extends BasePortableFakeFS {
   }
   async utimesPromise(p, atime, mtime) {
     return await new Promise((resolve, reject) => {
-      this.realFs.utimes(npath.fromPortablePath(p), atime, mtime, this.makeCallback(resolve, reject));
+      this.realFs.utimes(
+        npath.fromPortablePath(p),
+        atime,
+        mtime,
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   utimesSync(p, atime, mtime) {
@@ -1198,7 +1400,12 @@ class NodeFS extends BasePortableFakeFS {
   }
   async lutimesPromise(p, atime, mtime) {
     return await new Promise((resolve, reject) => {
-      this.realFs.lutimes(npath.fromPortablePath(p), atime, mtime, this.makeCallback(resolve, reject));
+      this.realFs.lutimes(
+        npath.fromPortablePath(p),
+        atime,
+        mtime,
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   lutimesSync(p, atime, mtime) {
@@ -1238,7 +1445,11 @@ class NodeFS extends BasePortableFakeFS {
   }
   async linkPromise(existingP, newP) {
     return await new Promise((resolve, reject) => {
-      this.realFs.link(npath.fromPortablePath(existingP), npath.fromPortablePath(newP), this.makeCallback(resolve, reject));
+      this.realFs.link(
+        npath.fromPortablePath(existingP),
+        npath.fromPortablePath(newP),
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   linkSync(existingP, newP) {
@@ -1246,11 +1457,20 @@ class NodeFS extends BasePortableFakeFS {
   }
   async symlinkPromise(target, p, type) {
     return await new Promise((resolve, reject) => {
-      this.realFs.symlink(npath.fromPortablePath(target.replace(/\/+$/, ``)), npath.fromPortablePath(p), type, this.makeCallback(resolve, reject));
+      this.realFs.symlink(
+        npath.fromPortablePath(target.replace(/\/+$/, ``)),
+        npath.fromPortablePath(p),
+        type,
+        this.makeCallback(resolve, reject)
+      );
     });
   }
   symlinkSync(target, p, type) {
-    return this.realFs.symlinkSync(npath.fromPortablePath(target.replace(/\/+$/, ``)), npath.fromPortablePath(p), type);
+    return this.realFs.symlinkSync(
+      npath.fromPortablePath(target.replace(/\/+$/, ``)),
+      npath.fromPortablePath(p),
+      type
+    );
   }
   async readFilePromise(p, encoding) {
     return await new Promise((resolve, reject) => {
@@ -1267,9 +1487,17 @@ class NodeFS extends BasePortableFakeFS {
       if (opts) {
         if (opts.recursive && process.platform === `win32`) {
           if (opts.withFileTypes) {
-            this.realFs.readdir(npath.fromPortablePath(p), opts, this.makeCallback((results) => resolve(results.map(direntToPortable)), reject));
+            this.realFs.readdir(
+              npath.fromPortablePath(p),
+              opts,
+              this.makeCallback((results) => resolve(results.map(direntToPortable)), reject)
+            );
           } else {
-            this.realFs.readdir(npath.fromPortablePath(p), opts, this.makeCallback((results) => resolve(results.map(npath.toPortablePath)), reject));
+            this.realFs.readdir(
+              npath.fromPortablePath(p),
+              opts,
+              this.makeCallback((results) => resolve(results.map(npath.toPortablePath)), reject)
+            );
           }
         } else {
           this.realFs.readdir(npath.fromPortablePath(p), opts, this.makeCallback(resolve, reject));
@@ -1351,7 +1579,8 @@ class NodeFS extends BasePortableFakeFS {
 }
 
 const NUMBER_REGEXP = /^[0-9]+$/;
-const VIRTUAL_REGEXP = /^(\/(?:[^/]+\/)*?(?:\$\$virtual|__virtual__))((?:\/((?:[^/]+-)?[a-f0-9]+)(?:\/([^/]+))?)?((?:\/.*)?))$/;
+const VIRTUAL_REGEXP =
+  /^(\/(?:[^/]+\/)*?(?:\$\$virtual|__virtual__))((?:\/((?:[^/]+-)?[a-f0-9]+)(?:\/([^/]+))?)?((?:\/.*)?))$/;
 const VALID_COMPONENT = /^([^/]+-)?[a-f0-9]+$/;
 class VirtualFS extends ProxiedFS {
   baseFs;
@@ -1363,22 +1592,18 @@ class VirtualFS extends ProxiedFS {
     const target = ppath.relative(ppath.dirname(base), to);
     const segments = target.split(`/`);
     let depth = 0;
-    while (depth < segments.length && segments[depth] === `..`)
-      depth += 1;
+    while (depth < segments.length && segments[depth] === `..`) depth += 1;
     const finalSegments = segments.slice(depth);
     const fullVirtualPath = ppath.join(base, component, String(depth), ...finalSegments);
     return fullVirtualPath;
   }
   static resolveVirtual(p) {
     const match = p.match(VIRTUAL_REGEXP);
-    if (!match || !match[3] && match[5])
-      return p;
+    if (!match || (!match[3] && match[5])) return p;
     const target = ppath.dirname(match[1]);
-    if (!match[3] || !match[4])
-      return target;
+    if (!match[3] || !match[4]) return target;
     const isnum = NUMBER_REGEXP.test(match[4]);
-    if (!isnum)
-      return p;
+    if (!isnum) return p;
     const depth = Number(match[4]);
     const backstep = `../`.repeat(depth);
     const subpath = match[5] || `.`;
@@ -1396,27 +1621,21 @@ class VirtualFS extends ProxiedFS {
   }
   realpathSync(p) {
     const match = p.match(VIRTUAL_REGEXP);
-    if (!match)
-      return this.baseFs.realpathSync(p);
-    if (!match[5])
-      return p;
+    if (!match) return this.baseFs.realpathSync(p);
+    if (!match[5]) return p;
     const realpath = this.baseFs.realpathSync(this.mapToBase(p));
     return VirtualFS.makeVirtualPath(match[1], match[3], realpath);
   }
   async realpathPromise(p) {
     const match = p.match(VIRTUAL_REGEXP);
-    if (!match)
-      return await this.baseFs.realpathPromise(p);
-    if (!match[5])
-      return p;
+    if (!match) return await this.baseFs.realpathPromise(p);
+    if (!match[5]) return p;
     const realpath = await this.baseFs.realpathPromise(this.mapToBase(p));
     return VirtualFS.makeVirtualPath(match[1], match[3], realpath);
   }
   mapToBase(p) {
-    if (p === ``)
-      return p;
-    if (this.pathUtils.isAbsolute(p))
-      return VirtualFS.resolveVirtual(p);
+    if (p === ``) return p;
+    if (this.pathUtils.isAbsolute(p)) return VirtualFS.resolveVirtual(p);
     const resolvedRoot = VirtualFS.resolveVirtual(this.baseFs.resolve(PortablePath.dot));
     const resolvedP = VirtualFS.resolveVirtual(this.baseFs.resolve(p));
     return ppath.relative(resolvedRoot, resolvedP) || PortablePath.dot;
@@ -1429,9 +1648,11 @@ class VirtualFS extends ProxiedFS {
 const URL = Number(process.versions.node.split('.', 1)[0]) < 20 ? URL$1 : globalThis.URL;
 
 const [major, minor] = process.versions.node.split(`.`).map((value) => parseInt(value, 10));
-const WATCH_MODE_MESSAGE_USES_ARRAYS = major > 19 || major === 19 && minor >= 2 || major === 18 && minor >= 13;
-const HAS_LAZY_LOADED_TRANSLATORS = major === 20 && minor < 6 || major === 19 && minor >= 3;
-const SUPPORTS_IMPORT_ATTRIBUTES = major >= 21 || major === 20 && minor >= 10 || major === 18 && minor >= 20;
+const WATCH_MODE_MESSAGE_USES_ARRAYS =
+  major > 19 || (major === 19 && minor >= 2) || (major === 18 && minor >= 13);
+const HAS_LAZY_LOADED_TRANSLATORS = (major === 20 && minor < 6) || (major === 19 && minor >= 3);
+const SUPPORTS_IMPORT_ATTRIBUTES =
+  major >= 21 || (major === 20 && minor >= 10) || (major === 18 && minor >= 20);
 const SUPPORTS_IMPORT_ATTRIBUTES_ONLY = major >= 22;
 
 function readPackageScope(checkPath) {
@@ -1440,8 +1661,7 @@ function readPackageScope(checkPath) {
   do {
     separatorIndex = checkPath.lastIndexOf(npath.sep);
     checkPath = checkPath.slice(0, separatorIndex);
-    if (checkPath.endsWith(`${npath.sep}node_modules`))
-      return false;
+    if (checkPath.endsWith(`${npath.sep}node_modules`)) return false;
     const pjson = readPackage(checkPath + npath.sep);
     if (pjson) {
       return {
@@ -1454,8 +1674,7 @@ function readPackageScope(checkPath) {
 }
 function readPackage(requestPath) {
   const jsonPath = npath.resolve(requestPath, `package.json`);
-  if (!fs.existsSync(jsonPath))
-    return null;
+  if (!fs.existsSync(jsonPath)) return null;
   return JSON.parse(fs.readFileSync(jsonPath, `utf8`));
 }
 
@@ -1463,8 +1682,7 @@ async function tryReadFile$1(path2) {
   try {
     return await fs.promises.readFile(path2, `utf8`);
   } catch (error) {
-    if (error.code === `ENOENT`)
-      return null;
+    if (error.code === `ENOENT`) return null;
     throw error;
   }
 }
@@ -1489,27 +1707,21 @@ function getFileFormat(filepath) {
       return `commonjs`;
     }
     case `.wasm`: {
-      throw new Error(
-        `Unknown file extension ".wasm" for ${filepath}`
-      );
+      throw new Error(`Unknown file extension ".wasm" for ${filepath}`);
     }
     case `.json`: {
       return `json`;
     }
     case `.js`: {
       const pkg = readPackageScope(filepath);
-      if (!pkg)
-        return `commonjs`;
+      if (!pkg) return `commonjs`;
       return pkg.data.type ?? `commonjs`;
     }
     default: {
-      if (entrypointPath !== filepath)
-        return null;
+      if (entrypointPath !== filepath) return null;
       const pkg = readPackageScope(filepath);
-      if (!pkg)
-        return `commonjs`;
-      if (pkg.data.type === `module`)
-        return null;
+      if (!pkg) return `commonjs`;
+      if (pkg.data.type === `module`) return null;
       return pkg.data.type ?? `commonjs`;
     }
   }
@@ -1517,23 +1729,28 @@ function getFileFormat(filepath) {
 
 async function load$1(urlString, context, nextLoad) {
   const url = tryParseURL(urlString);
-  if (url?.protocol !== `file:`)
-    return nextLoad(urlString, context, nextLoad);
+  if (url?.protocol !== `file:`) return nextLoad(urlString, context, nextLoad);
   const filePath = fileURLToPath(url);
   const format = getFileFormat(filePath);
-  if (!format)
-    return nextLoad(urlString, context, nextLoad);
+  if (!format) return nextLoad(urlString, context, nextLoad);
   if (format === `json`) {
     if (SUPPORTS_IMPORT_ATTRIBUTES_ONLY) {
       if (context.importAttributes?.type !== `json`) {
-        const err = new TypeError(`[ERR_IMPORT_ATTRIBUTE_MISSING]: Module "${urlString}" needs an import attribute of "type: json"`);
+        const err = new TypeError(
+          `[ERR_IMPORT_ATTRIBUTE_MISSING]: Module "${urlString}" needs an import attribute of "type: json"`
+        );
         err.code = `ERR_IMPORT_ATTRIBUTE_MISSING`;
         throw err;
       }
     } else {
-      const type = `importAttributes` in context ? context.importAttributes?.type : context.importAssertions?.type;
+      const type =
+        `importAttributes` in context
+          ? context.importAttributes?.type
+          : context.importAssertions?.type;
       if (type !== `json`) {
-        const err = new TypeError(`[ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "${urlString}" needs an import ${SUPPORTS_IMPORT_ATTRIBUTES ? `attribute` : `assertion`} of type "json"`);
+        const err = new TypeError(
+          `[ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "${urlString}" needs an import ${SUPPORTS_IMPORT_ATTRIBUTES ? `attribute` : `assertion`} of type "json"`
+        );
         err.code = `ERR_IMPORT_ASSERTION_TYPE_MISSING`;
         throw err;
       }
@@ -1541,12 +1758,10 @@ async function load$1(urlString, context, nextLoad) {
   }
   if (process.env.WATCH_REPORT_DEPENDENCIES && process.send) {
     const pathToSend = pathToFileURL(
-      npath.fromPortablePath(
-        VirtualFS.resolveVirtual(npath.toPortablePath(filePath))
-      )
+      npath.fromPortablePath(VirtualFS.resolveVirtual(npath.toPortablePath(filePath)))
     ).href;
     process.send({
-      "watch:import": WATCH_MODE_MESSAGE_USES_ARRAYS ? [pathToSend] : pathToSend
+      'watch:import': WATCH_MODE_MESSAGE_USES_ARRAYS ? [pathToSend] : pathToSend
     });
   }
   return {
@@ -1559,9 +1774,11 @@ async function load$1(urlString, context, nextLoad) {
 const ArrayIsArray = Array.isArray;
 const JSONStringify = JSON.stringify;
 const ObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
-const ObjectPrototypeHasOwnProperty = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
+const ObjectPrototypeHasOwnProperty = (obj, prop) =>
+  Object.prototype.hasOwnProperty.call(obj, prop);
 const RegExpPrototypeExec = (obj, string) => RegExp.prototype.exec.call(obj, string);
-const RegExpPrototypeSymbolReplace = (obj, ...rest) => RegExp.prototype[Symbol.replace].apply(obj, rest);
+const RegExpPrototypeSymbolReplace = (obj, ...rest) =>
+  RegExp.prototype[Symbol.replace].apply(obj, rest);
 const StringPrototypeEndsWith = (str, ...rest) => String.prototype.endsWith.apply(str, rest);
 const StringPrototypeIncludes = (str, ...rest) => String.prototype.includes.apply(str, rest);
 const StringPrototypeLastIndexOf = (str, ...rest) => String.prototype.lastIndexOf.apply(str, rest);
@@ -1598,7 +1815,11 @@ const ERR_INVALID_MODULE_SPECIFIER = createErrorType(
 const ERR_INVALID_PACKAGE_TARGET = createErrorType(
   `ERR_INVALID_PACKAGE_TARGET`,
   (pkgPath, key, target, isImport = false, base = void 0) => {
-    const relError = typeof target === `string` && !isImport && target.length && !StringPrototypeStartsWith(target, `./`);
+    const relError =
+      typeof target === `string` &&
+      !isImport &&
+      target.length &&
+      !StringPrototypeStartsWith(target, `./`);
     if (key === `.`) {
       assert(isImport === false);
       return `Invalid "exports" main target ${JSONStringify(target)} defined in the package config ${pkgPath}package.json${base ? ` imported from ${base}` : ``}${relError ? `; targets must start with "./"` : ``}`;
@@ -1641,7 +1862,7 @@ function getPackageConfig(path, specifier, base, readFileSyncFn) {
       exists: false,
       main: void 0,
       name: void 0,
-      type: "none",
+      type: 'none',
       exports: void 0,
       imports: void 0
     };
@@ -1654,28 +1875,30 @@ function getPackageConfig(path, specifier, base, readFileSyncFn) {
   } catch (error) {
     throw new ERR_INVALID_PACKAGE_CONFIG(
       path,
-      (base ? `"${specifier}" from ` : "") + fileURLToPath(base || specifier),
+      (base ? `"${specifier}" from ` : '') + fileURLToPath(base || specifier),
       error.message
     );
   }
   let { imports, main, name, type } = filterOwnProperties(packageJSON, [
-    "imports",
-    "main",
-    "name",
-    "type"
+    'imports',
+    'main',
+    'name',
+    'type'
   ]);
-  const exports = ObjectPrototypeHasOwnProperty(packageJSON, "exports") ? packageJSON.exports : void 0;
-  if (typeof imports !== "object" || imports === null) {
+  const exports = ObjectPrototypeHasOwnProperty(packageJSON, 'exports')
+    ? packageJSON.exports
+    : void 0;
+  if (typeof imports !== 'object' || imports === null) {
     imports = void 0;
   }
-  if (typeof main !== "string") {
+  if (typeof main !== 'string') {
     main = void 0;
   }
-  if (typeof name !== "string") {
+  if (typeof name !== 'string') {
     name = void 0;
   }
-  if (type !== "module" && type !== "commonjs") {
-    type = "none";
+  if (type !== 'module' && type !== 'commonjs') {
+    type = 'none';
   }
   const packageConfig = {
     pjsonPath: path,
@@ -1690,10 +1913,10 @@ function getPackageConfig(path, specifier, base, readFileSyncFn) {
   return packageConfig;
 }
 function getPackageScopeConfig(resolved, readFileSyncFn) {
-  let packageJSONUrl = new URL("./package.json", resolved);
+  let packageJSONUrl = new URL('./package.json', resolved);
   while (true) {
     const packageJSONPath2 = packageJSONUrl.pathname;
-    if (StringPrototypeEndsWith(packageJSONPath2, "node_modules/package.json")) {
+    if (StringPrototypeEndsWith(packageJSONPath2, 'node_modules/package.json')) {
       break;
     }
     const packageConfig2 = getPackageConfig(
@@ -1706,7 +1929,7 @@ function getPackageScopeConfig(resolved, readFileSyncFn) {
       return packageConfig2;
     }
     const lastPackageJSONUrl = packageJSONUrl;
-    packageJSONUrl = new URL("../package.json", packageJSONUrl);
+    packageJSONUrl = new URL('../package.json', packageJSONUrl);
     if (packageJSONUrl.pathname === lastPackageJSONUrl.pathname) {
       break;
     }
@@ -1717,7 +1940,7 @@ function getPackageScopeConfig(resolved, readFileSyncFn) {
     exists: false,
     main: void 0,
     name: void 0,
-    type: "none",
+    type: 'none',
     exports: void 0,
     imports: void 0
   };
@@ -1728,71 +1951,77 @@ function getPackageScopeConfig(resolved, readFileSyncFn) {
 function throwImportNotDefined(specifier, packageJSONUrl, base) {
   throw new ERR_PACKAGE_IMPORT_NOT_DEFINED(
     specifier,
-    packageJSONUrl && fileURLToPath(new URL(".", packageJSONUrl)),
+    packageJSONUrl && fileURLToPath(new URL('.', packageJSONUrl)),
     fileURLToPath(base)
   );
 }
 function throwInvalidSubpath(subpath, packageJSONUrl, internal, base) {
-  const reason = `request is not a valid subpath for the "${internal ? "imports" : "exports"}" resolution of ${fileURLToPath(packageJSONUrl)}`;
-  throw new ERR_INVALID_MODULE_SPECIFIER(
-    subpath,
-    reason,
-    base && fileURLToPath(base)
-  );
+  const reason = `request is not a valid subpath for the "${internal ? 'imports' : 'exports'}" resolution of ${fileURLToPath(packageJSONUrl)}`;
+  throw new ERR_INVALID_MODULE_SPECIFIER(subpath, reason, base && fileURLToPath(base));
 }
 function throwInvalidPackageTarget(subpath, target, packageJSONUrl, internal, base) {
-  if (typeof target === "object" && target !== null) {
-    target = JSONStringify(target, null, "");
+  if (typeof target === 'object' && target !== null) {
+    target = JSONStringify(target, null, '');
   } else {
     target = `${target}`;
   }
   throw new ERR_INVALID_PACKAGE_TARGET(
-    fileURLToPath(new URL(".", packageJSONUrl)),
+    fileURLToPath(new URL('.', packageJSONUrl)),
     subpath,
     target,
     internal,
     base && fileURLToPath(base)
   );
 }
-const invalidSegmentRegEx = /(^|\\|\/)((\.|%2e)(\.|%2e)?|(n|%6e|%4e)(o|%6f|%4f)(d|%64|%44)(e|%65|%45)(_|%5f)(m|%6d|%4d)(o|%6f|%4f)(d|%64|%44)(u|%75|%55)(l|%6c|%4c)(e|%65|%45)(s|%73|%53))(\\|\/|$)/i;
+const invalidSegmentRegEx =
+  /(^|\\|\/)((\.|%2e)(\.|%2e)?|(n|%6e|%4e)(o|%6f|%4f)(d|%64|%44)(e|%65|%45)(_|%5f)(m|%6d|%4d)(o|%6f|%4f)(d|%64|%44)(u|%75|%55)(l|%6c|%4c)(e|%65|%45)(s|%73|%53))(\\|\/|$)/i;
 const patternRegEx = /\*/g;
-function resolvePackageTargetString(target, subpath, match, packageJSONUrl, base, pattern, internal, conditions) {
-  if (subpath !== "" && !pattern && target[target.length - 1] !== "/")
+function resolvePackageTargetString(
+  target,
+  subpath,
+  match,
+  packageJSONUrl,
+  base,
+  pattern,
+  internal,
+  conditions
+) {
+  if (subpath !== '' && !pattern && target[target.length - 1] !== '/')
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
-  if (!StringPrototypeStartsWith(target, "./")) {
-    if (internal && !StringPrototypeStartsWith(target, "../") && !StringPrototypeStartsWith(target, "/")) {
+  if (!StringPrototypeStartsWith(target, './')) {
+    if (
+      internal &&
+      !StringPrototypeStartsWith(target, '../') &&
+      !StringPrototypeStartsWith(target, '/')
+    ) {
       let isURL = false;
       try {
         new URL(target);
         isURL = true;
-      } catch {
-      }
+      } catch {}
       if (!isURL) {
-        const exportTarget = pattern ? RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath) : target + subpath;
+        const exportTarget = pattern
+          ? RegExpPrototypeSymbolReplace(patternRegEx, target, () => subpath)
+          : target + subpath;
         return exportTarget;
       }
     }
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
   }
-  if (RegExpPrototypeExec(
-    invalidSegmentRegEx,
-    StringPrototypeSlice(target, 2)
-  ) !== null)
+  if (RegExpPrototypeExec(invalidSegmentRegEx, StringPrototypeSlice(target, 2)) !== null)
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
   const resolved = new URL(target, packageJSONUrl);
   const resolvedPath = resolved.pathname;
-  const packagePath = new URL(".", packageJSONUrl).pathname;
+  const packagePath = new URL('.', packageJSONUrl).pathname;
   if (!StringPrototypeStartsWith(resolvedPath, packagePath))
     throwInvalidPackageTarget(match, target, packageJSONUrl, internal, base);
-  if (subpath === "") return resolved;
+  if (subpath === '') return resolved;
   if (RegExpPrototypeExec(invalidSegmentRegEx, subpath) !== null) {
-    const request = pattern ? StringPrototypeReplace(match, "*", () => subpath) : match + subpath;
+    const request = pattern ? StringPrototypeReplace(match, '*', () => subpath) : match + subpath;
     throwInvalidSubpath(request, packageJSONUrl, internal, base);
   }
   if (pattern) {
-    return new URL(
-      RegExpPrototypeSymbolReplace(patternRegEx, resolved.href, () => subpath)
-    );
+    return new URL(RegExpPrototypeSymbolReplace(patternRegEx, resolved.href, () => subpath));
   }
   return new URL(subpath, resolved);
 }
@@ -1801,8 +2030,17 @@ function isArrayIndex(key) {
   if (`${keyNum}` !== key) return false;
   return keyNum >= 0 && keyNum < 4294967295;
 }
-function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, base, pattern, internal, conditions) {
-  if (typeof target === "string") {
+function resolvePackageTarget(
+  packageJSONUrl,
+  target,
+  subpath,
+  packageSubpath,
+  base,
+  pattern,
+  internal,
+  conditions
+) {
+  if (typeof target === 'string') {
     return resolvePackageTargetString(
       target,
       subpath,
@@ -1810,7 +2048,8 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, b
       packageJSONUrl,
       base,
       pattern,
-      internal);
+      internal
+    );
   } else if (ArrayIsArray(target)) {
     if (target.length === 0) {
       return null;
@@ -1832,7 +2071,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, b
         );
       } catch (e) {
         lastException = e;
-        if (e.code === "ERR_INVALID_PACKAGE_TARGET") {
+        if (e.code === 'ERR_INVALID_PACKAGE_TARGET') {
           continue;
         }
         throw e;
@@ -1846,10 +2085,9 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, b
       }
       return resolveResult;
     }
-    if (lastException === void 0 || lastException === null)
-      return lastException;
+    if (lastException === void 0 || lastException === null) return lastException;
     throw lastException;
-  } else if (typeof target === "object" && target !== null) {
+  } else if (typeof target === 'object' && target !== null) {
     const keys = ObjectGetOwnPropertyNames(target);
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
@@ -1863,7 +2101,7 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, b
     }
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
-      if (key === "default" || conditions.has(key)) {
+      if (key === 'default' || conditions.has(key)) {
         const conditionalTarget = target[key];
         const resolveResult = resolvePackageTarget(
           packageJSONUrl,
@@ -1883,17 +2121,11 @@ function resolvePackageTarget(packageJSONUrl, target, subpath, packageSubpath, b
   } else if (target === null) {
     return null;
   }
-  throwInvalidPackageTarget(
-    packageSubpath,
-    target,
-    packageJSONUrl,
-    internal,
-    base
-  );
+  throwInvalidPackageTarget(packageSubpath, target, packageJSONUrl, internal, base);
 }
 function patternKeyCompare(a, b) {
-  const aPatternIndex = StringPrototypeIndexOf(a, "*");
-  const bPatternIndex = StringPrototypeIndexOf(b, "*");
+  const aPatternIndex = StringPrototypeIndexOf(a, '*');
+  const bPatternIndex = StringPrototypeIndexOf(b, '*');
   const baseLenA = aPatternIndex === -1 ? a.length : aPatternIndex + 1;
   const baseLenB = bPatternIndex === -1 ? b.length : bPatternIndex + 1;
   if (baseLenA > baseLenB) return -1;
@@ -1905,8 +2137,8 @@ function patternKeyCompare(a, b) {
   return 0;
 }
 function packageImportsResolve({ name, base, conditions, readFileSyncFn }) {
-  if (name === "#" || StringPrototypeStartsWith(name, "#/") || StringPrototypeEndsWith(name, "/")) {
-    const reason = "is not a valid internal imports specifier name";
+  if (name === '#' || StringPrototypeStartsWith(name, '#/') || StringPrototypeEndsWith(name, '/')) {
+    const reason = 'is not a valid internal imports specifier name';
     throw new ERR_INVALID_MODULE_SPECIFIER(name, reason, fileURLToPath(base));
   }
   let packageJSONUrl;
@@ -1915,11 +2147,11 @@ function packageImportsResolve({ name, base, conditions, readFileSyncFn }) {
     packageJSONUrl = pathToFileURL(packageConfig.pjsonPath);
     const imports = packageConfig.imports;
     if (imports) {
-      if (ObjectPrototypeHasOwnProperty(imports, name) && !StringPrototypeIncludes(name, "*")) {
+      if (ObjectPrototypeHasOwnProperty(imports, name) && !StringPrototypeIncludes(name, '*')) {
         const resolveResult = resolvePackageTarget(
           packageJSONUrl,
           imports[name],
-          "",
+          '',
           name,
           base,
           false,
@@ -1930,18 +2162,23 @@ function packageImportsResolve({ name, base, conditions, readFileSyncFn }) {
           return resolveResult;
         }
       } else {
-        let bestMatch = "";
+        let bestMatch = '';
         let bestMatchSubpath;
         const keys = ObjectGetOwnPropertyNames(imports);
         for (let i = 0; i < keys.length; i++) {
           const key = keys[i];
-          const patternIndex = StringPrototypeIndexOf(key, "*");
-          if (patternIndex !== -1 && StringPrototypeStartsWith(
-            name,
-            StringPrototypeSlice(key, 0, patternIndex)
-          )) {
+          const patternIndex = StringPrototypeIndexOf(key, '*');
+          if (
+            patternIndex !== -1 &&
+            StringPrototypeStartsWith(name, StringPrototypeSlice(key, 0, patternIndex))
+          ) {
             const patternTrailer = StringPrototypeSlice(key, patternIndex + 1);
-            if (name.length >= key.length && StringPrototypeEndsWith(name, patternTrailer) && patternKeyCompare(bestMatch, key) === 1 && StringPrototypeLastIndexOf(key, "*") === patternIndex) {
+            if (
+              name.length >= key.length &&
+              StringPrototypeEndsWith(name, patternTrailer) &&
+              patternKeyCompare(bestMatch, key) === 1 &&
+              StringPrototypeLastIndexOf(key, '*') === patternIndex
+            ) {
               bestMatch = key;
               bestMatchSubpath = StringPrototypeSlice(
                 name,
@@ -1980,14 +2217,14 @@ if (!findPnpApi) {
   pnpApi.setup();
   findPnpApi = esmModule.findPnpApi;
 }
-const pathRegExp = /^(?![a-zA-Z]:[\\/]|\\\\|\.{0,2}(?:\/|$))((?:node:)?(?:@[^/]+\/)?[^/]+)\/*(.*|)$/;
+const pathRegExp =
+  /^(?![a-zA-Z]:[\\/]|\\\\|\.{0,2}(?:\/|$))((?:node:)?(?:@[^/]+\/)?[^/]+)\/*(.*|)$/;
 const isRelativeRegexp = /^\.{0,2}\//;
 function tryReadFile(filePath) {
   try {
     return fs.readFileSync(filePath, `utf8`);
   } catch (err) {
-    if (err.code === `ENOENT`)
-      return void 0;
+    if (err.code === `ENOENT`) return void 0;
     throw err;
   }
 }
@@ -2012,15 +2249,16 @@ async function resolve$1(originalSpecifier, context, nextResolve) {
   let specifier = originalSpecifier;
   const url = tryParseURL(specifier, isRelativeRegexp.test(specifier) ? context.parentURL : void 0);
   if (url) {
-    if (url.protocol !== `file:`)
-      return nextResolve(originalSpecifier, context, nextResolve);
+    if (url.protocol !== `file:`) return nextResolve(originalSpecifier, context, nextResolve);
     specifier = fileURLToPath(url);
   }
   const { parentURL, conditions = [] } = context;
-  const issuer = parentURL && tryParseURL(parentURL)?.protocol === `file:` ? fileURLToPath(parentURL) : process.cwd();
+  const issuer =
+    parentURL && tryParseURL(parentURL)?.protocol === `file:`
+      ? fileURLToPath(parentURL)
+      : process.cwd();
   const pnpapi = findPnpApi(issuer) ?? (url ? findPnpApi(specifier) : null);
-  if (!pnpapi)
-    return nextResolve(originalSpecifier, context, nextResolve);
+  if (!pnpapi) return nextResolve(originalSpecifier, context, nextResolve);
   if (specifier.startsWith(`#`))
     return resolvePrivateRequest(specifier, issuer, context, nextResolve);
   const dependencyNameMatch = specifier.match(pathRegExp);
@@ -2050,15 +2288,13 @@ async function resolve$1(originalSpecifier, context, nextResolve) {
       err.code = `ERR_MODULE_NOT_FOUND`;
     throw err;
   }
-  if (!result)
-    throw new Error(`Resolving '${specifier}' from '${issuer}' failed`);
+  if (!result) throw new Error(`Resolving '${specifier}' from '${issuer}' failed`);
   const resultURL = pathToFileURL(result);
   if (url) {
     resultURL.search = url.search;
     resultURL.hash = url.hash;
   }
-  if (!parentURL)
-    setEntrypointPath(fileURLToPath(resultURL));
+  if (!parentURL) setEntrypointPath(fileURLToPath(resultURL));
   return {
     url: resultURL.href,
     shortCircuit: true
@@ -2069,7 +2305,7 @@ if (!HAS_LAZY_LOADED_TRANSLATORS) {
   const binding = process.binding(`fs`);
   const originalReadFile = binding.readFileUtf8 || binding.readFileSync;
   if (originalReadFile) {
-    binding[originalReadFile.name] = function(...args) {
+    binding[originalReadFile.name] = function (...args) {
       try {
         return fs.readFileSync(args[0], {
           encoding: `utf8`,
@@ -2078,8 +2314,7 @@ if (!HAS_LAZY_LOADED_TRANSLATORS) {
           // which says it can be a number which matches the implementation.
           flag: args[1]
         });
-      } catch {
-      }
+      } catch {}
       return originalReadFile.apply(this, args);
     };
   } else {
@@ -2087,7 +2322,7 @@ if (!HAS_LAZY_LOADED_TRANSLATORS) {
     const originalfstat = binding2.fstat;
     const ZIP_MASK = 4278190080;
     const ZIP_MAGIC = 704643072;
-    binding2.fstat = function(...args) {
+    binding2.fstat = function (...args) {
       const [fd, useBigint, req] = args;
       if ((fd & ZIP_MASK) === ZIP_MAGIC && useBigint === false && req === void 0) {
         try {
@@ -2112,8 +2347,7 @@ if (!HAS_LAZY_LOADED_TRANSLATORS) {
             // birthtime sec
             // birthtime ns
           ]);
-        } catch {
-        }
+        } catch {}
       }
       return originalfstat.apply(this, args);
     };

--- a/.yarn/sdks/eslint/bin/eslint.js
+++ b/.yarn/sdks/eslint/bin/eslint.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,8 +25,8 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
 // Defer to the real eslint/bin/eslint.js your application uses
 module.exports = wrapWithUserWrapper(absRequire(`eslint/bin/eslint.js`));

--- a/.yarn/sdks/eslint/lib/api.js
+++ b/.yarn/sdks/eslint/lib/api.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,8 +25,8 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
 // Defer to the real eslint your application uses
 module.exports = wrapWithUserWrapper(absRequire(`eslint`));

--- a/.yarn/sdks/eslint/lib/unsupported-api.js
+++ b/.yarn/sdks/eslint/lib/unsupported-api.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,8 +25,8 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
 // Defer to the real eslint/use-at-your-own-risk your application uses
 module.exports = wrapWithUserWrapper(absRequire(`eslint/use-at-your-own-risk`));

--- a/.yarn/sdks/typescript/lib/tsc.js
+++ b/.yarn/sdks/typescript/lib/tsc.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,8 +25,8 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
 // Defer to the real typescript/lib/tsc.js your application uses
 module.exports = wrapWithUserWrapper(absRequire(`typescript/lib/tsc.js`));

--- a/.yarn/sdks/typescript/lib/tsserver.js
+++ b/.yarn/sdks/typescript/lib/tsserver.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,28 +25,30 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
-const moduleWrapper = exports => {
+const moduleWrapper = (exports) => {
   return wrapWithUserWrapper(moduleWrapperFn(exports));
 };
 
-const moduleWrapperFn = tsserver => {
+const moduleWrapperFn = (tsserver) => {
   if (!process.versions.pnp) {
     return tsserver;
   }
 
-  const {isAbsolute} = require(`path`);
+  const { isAbsolute } = require(`path`);
   const pnpApi = require(`pnpapi`);
 
-  const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
-  const isPortal = str => str.startsWith("portal:/");
-  const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
+  const isVirtual = (str) => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = (str) => str.startsWith('portal:/');
+  const normalize = (str) => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
-  const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
-    return `${locator.name}@${locator.reference}`;
-  }));
+  const dependencyTreeRoots = new Set(
+    pnpApi.getDependencyTreeRoots().map((locator) => {
+      return `${locator.name}@${locator.reference}`;
+    })
+  );
 
   // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
   // doesn't understand. This layer makes sure to remove the protocol
@@ -54,7 +56,11 @@ const moduleWrapperFn = tsserver => {
 
   function toEditorPath(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
-    if (isAbsolute(str) && !str.match(/^\^?(zip:|\/zip\/)/) && (str.match(/\.zip\//) || isVirtual(str))) {
+    if (
+      isAbsolute(str) &&
+      !str.match(/^\^?(zip:|\/zip\/)/) &&
+      (str.match(/\.zip\//) || isVirtual(str))
+    ) {
       // We also take the opportunity to turn virtual paths into physical ones;
       // this makes it much easier to work with workspaces that list peer
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
@@ -68,7 +74,11 @@ const moduleWrapperFn = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
+        if (
+          locator &&
+          (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) ||
+            isPortal(locator.reference))
+        ) {
           str = resolved;
         }
       }
@@ -96,41 +106,55 @@ const moduleWrapperFn = tsserver => {
           // Before | ^/zip/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
           //
-          case `vscode <1.61`: {
-            str = `^zip:${str}`;
-          } break;
+          case `vscode <1.61`:
+            {
+              str = `^zip:${str}`;
+            }
+            break;
 
-          case `vscode <1.66`: {
-            str = `^/zip/${str}`;
-          } break;
+          case `vscode <1.66`:
+            {
+              str = `^/zip/${str}`;
+            }
+            break;
 
-          case `vscode <1.68`: {
-            str = `^/zip${str}`;
-          } break;
+          case `vscode <1.68`:
+            {
+              str = `^/zip${str}`;
+            }
+            break;
 
-          case `vscode`: {
-            str = `^/zip/${str}`;
-          } break;
+          case `vscode`:
+            {
+              str = `^/zip/${str}`;
+            }
+            break;
 
           // To make "go to definition" work,
           // We have to resolve the actual file system path from virtual path
           // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
-          case `coc-nvim`: {
-            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = resolve(`zipfile:${str}`);
-          } break;
+          case `coc-nvim`:
+            {
+              str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+              str = resolve(`zipfile:${str}`);
+            }
+            break;
 
           // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
           // We have to resolve the actual file system path from virtual path,
           // everything else is up to neovim
-          case `neovim`: {
-            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile://${str}`;
-          } break;
+          case `neovim`:
+            {
+              str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+              str = `zipfile://${str}`;
+            }
+            break;
 
-          default: {
-            str = `zip:${str}`;
-          } break;
+          default:
+            {
+              str = `zip:${str}`;
+            }
+            break;
         }
       } else {
         str = str.replace(/^\/?/, process.platform === `win32` ? `` : `/`);
@@ -142,26 +166,35 @@ const moduleWrapperFn = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`: {
-        str = str.replace(/\.zip::/, `.zip/`);
-        // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
-        // So in order to convert it back, we use .* to match all the thing
-        // before `zipfile:`
-        return process.platform === `win32`
-          ? str.replace(/^.*zipfile:\//, ``)
-          : str.replace(/^.*zipfile:/, ``);
-      } break;
+      case `coc-nvim`:
+        {
+          str = str.replace(/\.zip::/, `.zip/`);
+          // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+          // So in order to convert it back, we use .* to match all the thing
+          // before `zipfile:`
+          return process.platform === `win32`
+            ? str.replace(/^.*zipfile:\//, ``)
+            : str.replace(/^.*zipfile:/, ``);
+        }
+        break;
 
-      case `neovim`: {
-        str = str.replace(/\.zip::/, `.zip/`);
-        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
-        return str.replace(/^zipfile:\/\//, ``);
-      } break;
+      case `neovim`:
+        {
+          str = str.replace(/\.zip::/, `.zip/`);
+          // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+          return str.replace(/^zipfile:\/\//, ``);
+        }
+        break;
 
       case `vscode`:
-      default: {
-        return str.replace(/^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/, process.platform === `win32` ? `` : `/`)
-      } break;
+      default:
+        {
+          return str.replace(
+            /^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/,
+            process.platform === `win32` ? `` : `/`
+          );
+        }
+        break;
     }
   }
 
@@ -173,8 +206,9 @@ const moduleWrapperFn = tsserver => {
   // TypeScript already does local loads and if this code is running the user trusts the workspace
   // https://github.com/microsoft/vscode/issues/45856
   const ConfiguredProject = tsserver.server.ConfiguredProject;
-  const {enablePluginsWithOptions: originalEnablePluginsWithOptions} = ConfiguredProject.prototype;
-  ConfiguredProject.prototype.enablePluginsWithOptions = function() {
+  const { enablePluginsWithOptions: originalEnablePluginsWithOptions } =
+    ConfiguredProject.prototype;
+  ConfiguredProject.prototype.enablePluginsWithOptions = function () {
     this.projectService.allowLocalPluginLoads = true;
     return originalEnablePluginsWithOptions.apply(this, arguments);
   };
@@ -184,7 +218,7 @@ const moduleWrapperFn = tsserver => {
   // like an absolute path of ours and normalize it.
 
   const Session = tsserver.server.Session;
-  const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
+  const { onMessage: originalOnMessage, send: originalSend } = Session.prototype;
   let hostInfo = `unknown`;
 
   Object.assign(Session.prototype, {
@@ -200,10 +234,12 @@ const moduleWrapperFn = tsserver => {
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
         if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
-          const [, major, minor] = (process.env.VSCODE_IPC_HOOK.match(
-            // The RegExp from https://semver.org/ but without the caret at the start
-            /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-          ) ?? []).map(Number)
+          const [, major, minor] = (
+            process.env.VSCODE_IPC_HOOK.match(
+              // The RegExp from https://semver.org/ but without the caret at the start
+              /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+            ) ?? []
+          ).map(Number);
 
           if (major === 1) {
             if (minor < 61) {
@@ -228,16 +264,23 @@ const moduleWrapperFn = tsserver => {
     },
 
     send(/** @type {any} */ msg) {
-      return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
-        return typeof value === `string` ? toEditorPath(value) : value;
-      })));
+      return originalSend.call(
+        this,
+        JSON.parse(
+          JSON.stringify(msg, (key, value) => {
+            return typeof value === `string` ? toEditorPath(value) : value;
+          })
+        )
+      );
     }
   });
 
   return tsserver;
 };
 
-const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+const [major, minor] = absRequire(`typescript/package.json`)
+  .version.split(`.`, 2)
+  .map((value) => parseInt(value, 10));
 // In TypeScript@>=5.5 the tsserver uses the public TypeScript API so that needs to be patched as well.
 // Ref https://github.com/microsoft/TypeScript/pull/55326
 if (major > 5 || (major === 5 && minor >= 5)) {

--- a/.yarn/sdks/typescript/lib/tsserverlibrary.js
+++ b/.yarn/sdks/typescript/lib/tsserverlibrary.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,28 +25,30 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
-const moduleWrapper = exports => {
+const moduleWrapper = (exports) => {
   return wrapWithUserWrapper(moduleWrapperFn(exports));
 };
 
-const moduleWrapperFn = tsserver => {
+const moduleWrapperFn = (tsserver) => {
   if (!process.versions.pnp) {
     return tsserver;
   }
 
-  const {isAbsolute} = require(`path`);
+  const { isAbsolute } = require(`path`);
   const pnpApi = require(`pnpapi`);
 
-  const isVirtual = str => str.match(/\/(\$\$virtual|__virtual__)\//);
-  const isPortal = str => str.startsWith("portal:/");
-  const normalize = str => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
+  const isVirtual = (str) => str.match(/\/(\$\$virtual|__virtual__)\//);
+  const isPortal = (str) => str.startsWith('portal:/');
+  const normalize = (str) => str.replace(/\\/g, `/`).replace(/^\/?/, `/`);
 
-  const dependencyTreeRoots = new Set(pnpApi.getDependencyTreeRoots().map(locator => {
-    return `${locator.name}@${locator.reference}`;
-  }));
+  const dependencyTreeRoots = new Set(
+    pnpApi.getDependencyTreeRoots().map((locator) => {
+      return `${locator.name}@${locator.reference}`;
+    })
+  );
 
   // VSCode sends the zip paths to TS using the "zip://" prefix, that TS
   // doesn't understand. This layer makes sure to remove the protocol
@@ -54,7 +56,11 @@ const moduleWrapperFn = tsserver => {
 
   function toEditorPath(str) {
     // We add the `zip:` prefix to both `.zip/` paths and virtual paths
-    if (isAbsolute(str) && !str.match(/^\^?(zip:|\/zip\/)/) && (str.match(/\.zip\//) || isVirtual(str))) {
+    if (
+      isAbsolute(str) &&
+      !str.match(/^\^?(zip:|\/zip\/)/) &&
+      (str.match(/\.zip\//) || isVirtual(str))
+    ) {
       // We also take the opportunity to turn virtual paths into physical ones;
       // this makes it much easier to work with workspaces that list peer
       // dependencies, since otherwise Ctrl+Click would bring us to the virtual
@@ -68,7 +74,11 @@ const moduleWrapperFn = tsserver => {
       const resolved = isVirtual(str) ? pnpApi.resolveVirtual(str) : str;
       if (resolved) {
         const locator = pnpApi.findPackageLocator(resolved);
-        if (locator && (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) || isPortal(locator.reference))) {
+        if (
+          locator &&
+          (dependencyTreeRoots.has(`${locator.name}@${locator.reference}`) ||
+            isPortal(locator.reference))
+        ) {
           str = resolved;
         }
       }
@@ -96,41 +106,55 @@ const moduleWrapperFn = tsserver => {
           // Before | ^/zip/c:/foo/bar.zip/package.json
           // After  | ^/zip//c:/foo/bar.zip/package.json
           //
-          case `vscode <1.61`: {
-            str = `^zip:${str}`;
-          } break;
+          case `vscode <1.61`:
+            {
+              str = `^zip:${str}`;
+            }
+            break;
 
-          case `vscode <1.66`: {
-            str = `^/zip/${str}`;
-          } break;
+          case `vscode <1.66`:
+            {
+              str = `^/zip/${str}`;
+            }
+            break;
 
-          case `vscode <1.68`: {
-            str = `^/zip${str}`;
-          } break;
+          case `vscode <1.68`:
+            {
+              str = `^/zip${str}`;
+            }
+            break;
 
-          case `vscode`: {
-            str = `^/zip/${str}`;
-          } break;
+          case `vscode`:
+            {
+              str = `^/zip/${str}`;
+            }
+            break;
 
           // To make "go to definition" work,
           // We have to resolve the actual file system path from virtual path
           // and convert scheme to supported by [vim-rzip](https://github.com/lbrayner/vim-rzip)
-          case `coc-nvim`: {
-            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = resolve(`zipfile:${str}`);
-          } break;
+          case `coc-nvim`:
+            {
+              str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+              str = resolve(`zipfile:${str}`);
+            }
+            break;
 
           // Support neovim native LSP and [typescript-language-server](https://github.com/theia-ide/typescript-language-server)
           // We have to resolve the actual file system path from virtual path,
           // everything else is up to neovim
-          case `neovim`: {
-            str = normalize(resolved).replace(/\.zip\//, `.zip::`);
-            str = `zipfile://${str}`;
-          } break;
+          case `neovim`:
+            {
+              str = normalize(resolved).replace(/\.zip\//, `.zip::`);
+              str = `zipfile://${str}`;
+            }
+            break;
 
-          default: {
-            str = `zip:${str}`;
-          } break;
+          default:
+            {
+              str = `zip:${str}`;
+            }
+            break;
         }
       } else {
         str = str.replace(/^\/?/, process.platform === `win32` ? `` : `/`);
@@ -142,26 +166,35 @@ const moduleWrapperFn = tsserver => {
 
   function fromEditorPath(str) {
     switch (hostInfo) {
-      case `coc-nvim`: {
-        str = str.replace(/\.zip::/, `.zip/`);
-        // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
-        // So in order to convert it back, we use .* to match all the thing
-        // before `zipfile:`
-        return process.platform === `win32`
-          ? str.replace(/^.*zipfile:\//, ``)
-          : str.replace(/^.*zipfile:/, ``);
-      } break;
+      case `coc-nvim`:
+        {
+          str = str.replace(/\.zip::/, `.zip/`);
+          // The path for coc-nvim is in format of /<pwd>/zipfile:/<pwd>/.yarn/...
+          // So in order to convert it back, we use .* to match all the thing
+          // before `zipfile:`
+          return process.platform === `win32`
+            ? str.replace(/^.*zipfile:\//, ``)
+            : str.replace(/^.*zipfile:/, ``);
+        }
+        break;
 
-      case `neovim`: {
-        str = str.replace(/\.zip::/, `.zip/`);
-        // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
-        return str.replace(/^zipfile:\/\//, ``);
-      } break;
+      case `neovim`:
+        {
+          str = str.replace(/\.zip::/, `.zip/`);
+          // The path for neovim is in format of zipfile:///<pwd>/.yarn/...
+          return str.replace(/^zipfile:\/\//, ``);
+        }
+        break;
 
       case `vscode`:
-      default: {
-        return str.replace(/^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/, process.platform === `win32` ? `` : `/`)
-      } break;
+      default:
+        {
+          return str.replace(
+            /^\^?(zip:|\/zip(\/ts-nul-authority)?)\/+/,
+            process.platform === `win32` ? `` : `/`
+          );
+        }
+        break;
     }
   }
 
@@ -173,8 +206,9 @@ const moduleWrapperFn = tsserver => {
   // TypeScript already does local loads and if this code is running the user trusts the workspace
   // https://github.com/microsoft/vscode/issues/45856
   const ConfiguredProject = tsserver.server.ConfiguredProject;
-  const {enablePluginsWithOptions: originalEnablePluginsWithOptions} = ConfiguredProject.prototype;
-  ConfiguredProject.prototype.enablePluginsWithOptions = function() {
+  const { enablePluginsWithOptions: originalEnablePluginsWithOptions } =
+    ConfiguredProject.prototype;
+  ConfiguredProject.prototype.enablePluginsWithOptions = function () {
     this.projectService.allowLocalPluginLoads = true;
     return originalEnablePluginsWithOptions.apply(this, arguments);
   };
@@ -184,7 +218,7 @@ const moduleWrapperFn = tsserver => {
   // like an absolute path of ours and normalize it.
 
   const Session = tsserver.server.Session;
-  const {onMessage: originalOnMessage, send: originalSend} = Session.prototype;
+  const { onMessage: originalOnMessage, send: originalSend } = Session.prototype;
   let hostInfo = `unknown`;
 
   Object.assign(Session.prototype, {
@@ -200,10 +234,12 @@ const moduleWrapperFn = tsserver => {
       ) {
         hostInfo = parsedMessage.arguments.hostInfo;
         if (hostInfo === `vscode` && process.env.VSCODE_IPC_HOOK) {
-          const [, major, minor] = (process.env.VSCODE_IPC_HOOK.match(
-            // The RegExp from https://semver.org/ but without the caret at the start
-            /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
-          ) ?? []).map(Number)
+          const [, major, minor] = (
+            process.env.VSCODE_IPC_HOOK.match(
+              // The RegExp from https://semver.org/ but without the caret at the start
+              /(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/
+            ) ?? []
+          ).map(Number);
 
           if (major === 1) {
             if (minor < 61) {
@@ -228,16 +264,23 @@ const moduleWrapperFn = tsserver => {
     },
 
     send(/** @type {any} */ msg) {
-      return originalSend.call(this, JSON.parse(JSON.stringify(msg, (key, value) => {
-        return typeof value === `string` ? toEditorPath(value) : value;
-      })));
+      return originalSend.call(
+        this,
+        JSON.parse(
+          JSON.stringify(msg, (key, value) => {
+            return typeof value === `string` ? toEditorPath(value) : value;
+          })
+        )
+      );
     }
   });
 
   return tsserver;
 };
 
-const [major, minor] = absRequire(`typescript/package.json`).version.split(`.`, 2).map(value => parseInt(value, 10));
+const [major, minor] = absRequire(`typescript/package.json`)
+  .version.split(`.`, 2)
+  .map((value) => parseInt(value, 10));
 // In TypeScript@>=5.5 the tsserver uses the public TypeScript API so that needs to be patched as well.
 // Ref https://github.com/microsoft/TypeScript/pull/55326
 if (major > 5 || (major === 5 && minor >= 5)) {

--- a/.yarn/sdks/typescript/lib/typescript.js
+++ b/.yarn/sdks/typescript/lib/typescript.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const {existsSync} = require(`fs`);
-const {createRequire, register} = require(`module`);
-const {resolve} = require(`path`);
-const {pathToFileURL} = require(`url`);
+const { existsSync } = require(`fs`);
+const { createRequire, register } = require(`module`);
+const { resolve } = require(`path`);
+const { pathToFileURL } = require(`url`);
 
-const relPnpApiPath = "../../../../.pnp.cjs";
+const relPnpApiPath = '../../../../.pnp.cjs';
 
 const absPnpApiPath = resolve(__dirname, relPnpApiPath);
 const absUserWrapperPath = resolve(__dirname, `./sdk.user.cjs`);
@@ -25,8 +25,8 @@ if (existsSync(absPnpApiPath)) {
 }
 
 const wrapWithUserWrapper = existsSync(absUserWrapperPath)
-  ? exports => absRequire(absUserWrapperPath)(exports)
-  : exports => exports;
+  ? (exports) => absRequire(absUserWrapperPath)(exports)
+  : (exports) => exports;
 
 // Defer to the real typescript your application uses
 module.exports = wrapWithUserWrapper(absRequire(`typescript`));

--- a/client/src/components/ui/avatar.tsx
+++ b/client/src/components/ui/avatar.tsx
@@ -1,34 +1,25 @@
-"use client"
+'use client'
 
-import * as React from "react"
-import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import * as AvatarPrimitive from '@radix-ui/react-avatar'
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Avatar({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Root>) {
+function Avatar({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Root>) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
-      className={cn(
-        "relative flex size-8 shrink-0 overflow-hidden rounded-full",
-        className
-      )}
+      className={cn('relative flex size-8 shrink-0 overflow-hidden rounded-full', className)}
       {...props}
     />
   )
 }
 
-function AvatarImage({
-  className,
-  ...props
-}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn('aspect-square size-full', className)}
       {...props}
     />
   )
@@ -41,10 +32,7 @@ function AvatarFallback({
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
-      className={cn(
-        "bg-muted flex size-full items-center justify-center rounded-full",
-        className
-      )}
+      className={cn('bg-muted flex size-full items-center justify-center rounded-full', className)}
       {...props}
     />
   )

--- a/client/src/components/ui/pagination.tsx
+++ b/client/src/components/ui/pagination.tsx
@@ -1,79 +1,72 @@
-import * as React from "react"
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  MoreHorizontalIcon,
-} from "lucide-react"
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react'
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
-function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+function Pagination({ className, ...props }: React.ComponentProps<'nav'>) {
   return (
     <nav
       role="navigation"
       aria-label="pagination"
       data-slot="pagination"
-      className={cn("mx-auto flex w-full justify-center", className)}
+      className={cn('mx-auto flex w-full justify-center', className)}
       {...props}
     />
   )
 }
 
-function PaginationContent({
-  className,
-  ...props
-}: React.ComponentProps<"ul">) {
+function PaginationContent({ className, ...props }: React.ComponentProps<'ul'>) {
   return (
     <ul
       data-slot="pagination-content"
-      className={cn("flex flex-row items-center gap-1", className)}
+      className={cn('flex flex-row items-center gap-1', className)}
       {...props}
     />
   )
 }
 
-function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
   return <li data-slot="pagination-item" {...props} />
 }
 
 type PaginationLinkProps = {
   isActive?: boolean
-} & Pick<React.ComponentProps<typeof Button>, "size"> &
-  React.ComponentProps<"a">
+} & Pick<React.ComponentProps<typeof Button>, 'size'> &
+  React.ComponentProps<'a'>
 
 function PaginationLink({
   className,
   isActive,
-  size = "icon",
+  size = 'icon',
+  children,
   ...props
 }: PaginationLinkProps) {
   return (
     <a
-      aria-current={isActive ? "page" : undefined}
+      aria-current={isActive ? 'page' : undefined}
       data-slot="pagination-link"
       data-active={isActive}
       className={cn(
         buttonVariants({
-          variant: isActive ? "outline" : "ghost",
+          variant: isActive ? 'outline' : 'ghost',
           size,
         }),
-        className
+        className,
       )}
       {...props}
-    />
+    >
+      {children}
+    </a>
   )
 }
 
-function PaginationPrevious({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) {
+function PaginationPrevious({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
       aria-label="Go to previous page"
       size="default"
-      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      className={cn('gap-1 px-2.5 sm:pl-2.5', className)}
       {...props}
     >
       <ChevronLeftIcon />
@@ -82,15 +75,12 @@ function PaginationPrevious({
   )
 }
 
-function PaginationNext({
-  className,
-  ...props
-}: React.ComponentProps<typeof PaginationLink>) {
+function PaginationNext({ className, ...props }: React.ComponentProps<typeof PaginationLink>) {
   return (
     <PaginationLink
       aria-label="Go to next page"
       size="default"
-      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      className={cn('gap-1 px-2.5 sm:pr-2.5', className)}
       {...props}
     >
       <span className="hidden sm:block">Next</span>
@@ -99,15 +89,12 @@ function PaginationNext({
   )
 }
 
-function PaginationEllipsis({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function PaginationEllipsis({ className, ...props }: React.ComponentProps<'span'>) {
   return (
     <span
       aria-hidden
       data-slot="pagination-ellipsis"
-      className={cn("flex size-9 items-center justify-center", className)}
+      className={cn('flex size-9 items-center justify-center', className)}
       {...props}
     >
       <MoreHorizontalIcon className="size-4" />

--- a/client/src/components/ui/separator.tsx
+++ b/client/src/components/ui/separator.tsx
@@ -1,11 +1,11 @@
-import * as React from "react"
-import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import * as SeparatorPrimitive from '@radix-ui/react-separator'
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 function Separator({
   className,
-  orientation = "horizontal",
+  orientation = 'horizontal',
   decorative = true,
   ...props
 }: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
@@ -15,8 +15,8 @@ function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
-        className
+        'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+        className,
       )}
       {...props}
     />

--- a/client/src/components/ui/table.tsx
+++ b/client/src/components/ui/table.tsx
@@ -1,114 +1,90 @@
-import * as React from "react"
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
-function Table({ className, ...props }: React.ComponentProps<"table">) {
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
-        className={cn("w-full caption-bottom text-sm", className)}
+        className={cn('w-full caption-bottom text-sm', className)}
         {...props}
       />
     </div>
   )
 }
 
-function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  )
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return <thead data-slot="table-header" className={cn('[&_tr]:border-b', className)} {...props} />
 }
 
-function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn('[&_tr:last-child]:border-0', className)}
       {...props}
     />
   )
 }
 
-function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
       {...props}
     />
   )
 }
 
-function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
   return (
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
   return (
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
   return (
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
       )}
       {...props}
     />
   )
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
   return (
     <caption
       data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
       {...props}
     />
   )
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/client/src/components/ui/tooltip.tsx
+++ b/client/src/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+import * as TooltipPrimitive from '@radix-ui/react-tooltip'
+import * as React from 'react'
 
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils'
 
 function TooltipProvider({
   delayDuration = 0,
@@ -16,9 +16,7 @@ function TooltipProvider({
   )
 }
 
-function Tooltip({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -26,9 +24,7 @@ function Tooltip({
   )
 }
 
-function TooltipTrigger({
-  ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
@@ -44,8 +40,8 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
-          className
+          'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance',
+          className,
         )}
         {...props}
       >

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,12 +1,7 @@
 import axios from 'axios'
 
-/**
- * Cria uma instância do cliente HTTP Axios com a baseURL da API.
- * Adiciona um interceptor de requisição para incluir o token de acesso no cabeçalho Authorization.
- * Se o token não estiver presente, a requisição será enviada sem o cabeçalho.
- */
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: `${import.meta.env.VITE_API_BASE_URL || ''}/api`,
 })
 
 api.interceptors.request.use(

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -44,5 +44,11 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
   },
 })

--- a/server/src/controllers/festaController.js
+++ b/server/src/controllers/festaController.js
@@ -6,8 +6,6 @@ import axios from 'axios';
 export async function criarFesta(req, res) {
   const { dadosFesta, dadosCliente } = req.body;
 
-  const idAdmEspacoLogado = req.usuarioId;
-
   if (!dadosFesta || !dadosCliente || !dadosCliente.email || !dadosFesta.nome_festa) {
     return res
       .status(400)
@@ -41,7 +39,7 @@ export async function criarFesta(req, res) {
       await clienteOrganizador.save();
 
       const webhookUrl =
-        'https://webhook.4growthbr.space/webhook/2cd048a2-c416-4e42-8202-e0979aa36cca'; 
+        'https://webhook.4growthbr.space/webhook/2cd048a2-c416-4e42-8202-e0979aa36cca';
       try {
         const payloadWebhook = {
           nomeCliente: clienteOrganizador.nome,
@@ -51,7 +49,7 @@ export async function criarFesta(req, res) {
           token: tokenDefinicaoSenha
         };
 
-        
+        // eslint-disable-next-line no-console
         console.log('Enviando dados para o webhook n8n:', payloadWebhook);
 
         axios.post(webhookUrl, payloadWebhook).catch((webhookError) => {
@@ -64,7 +62,7 @@ export async function criarFesta(req, res) {
         console.error('Erro ao tentar disparar o webhook para n8n:', webhookError.message);
       }
     } else {
-      
+      // eslint-disable-next-line no-console
       console.log(`Cliente já existente encontrado: ${clienteOrganizador.email}`);
     }
 
@@ -435,7 +433,7 @@ export async function deletarConvidado(req, res) {
 export async function checkinConvidado(req, res) {
   try {
     const { idFesta, idConvidado } = req.params;
-    const { usuarioId, usuarioTipo } = req;
+    const { _usuarioId, usuarioTipo } = req;
 
     if (usuarioTipo !== models.Usuario.TIPOS_USUARIO.ADM_ESPACO) {
       return res
@@ -451,8 +449,6 @@ export async function checkinConvidado(req, res) {
     }
 
     if (convidado.checkin_at) {
-
-      
       return res
         .status(400)
         .json({ error: `Check-in já realizado para este convidado em ${convidado.checkin_at}.` });
@@ -462,29 +458,28 @@ export async function checkinConvidado(req, res) {
     await convidado.save();
 
     const webhookUrl =
-        'https://webhook.4growthbr.space/webhook/ab98ae95-08c2-40b2-a942-c40071b588eb'; // URL CheckIN
-      try {
-        const payloadWebhook = {
-          nomeCliente: convidado.nome_convidado,
-          emailCliente: convidado.emailCliente,
-          telefoneCliente: convidado.telefoneCliente,
+      'https://webhook.4growthbr.space/webhook/ab98ae95-08c2-40b2-a942-c40071b588eb'; // URL CheckIN
+    try {
+      const payloadWebhook = {
+        nomeCliente: convidado.nome_convidado,
+        emailCliente: convidado.emailCliente,
+        telefoneCliente: convidado.telefoneCliente,
 
-          mensagem: `Check-in já realizado para este convidado em ${convidado.checkin_at}.`,
-        };
+        mensagem: `Check-in já realizado para este convidado em ${convidado.checkin_at}.`
+      };
 
-        
-        console.log('Enviando dados para o webhook n8n:', payloadWebhook);
+      // eslint-disable-next-line no-console
+      console.log('Enviando dados para o webhook n8n:', payloadWebhook);
 
-        axios.post(webhookUrl, payloadWebhook).catch((webhookError) => {
-          console.error(
-            'Erro secundário ao enviar o webhook para n8n:',
-            webhookError.response ? webhookError.response.data : webhookError.message
-          );
-        });
-      } catch (webhookError) {
-        console.error('Erro ao tentar disparar o webhook para n8n:', webhookError.message);
-      }
-
+      axios.post(webhookUrl, payloadWebhook).catch((webhookError) => {
+        console.error(
+          'Erro secundário ao enviar o webhook para n8n:',
+          webhookError.response ? webhookError.response.data : webhookError.message
+        );
+      });
+    } catch (webhookError) {
+      console.error('Erro ao tentar disparar o webhook para n8n:', webhookError.message);
+    }
 
     return res.status(200).json({ mensagem: 'Check-in realizado com sucesso!', convidado });
   } catch (error) {
@@ -496,7 +491,7 @@ export async function checkinConvidado(req, res) {
 export async function checkoutConvidado(req, res) {
   try {
     const { idFesta, idConvidado } = req.params;
-    const { usuarioId, usuarioTipo } = req;
+    const { _usuarioId, usuarioTipo } = req;
 
     if (usuarioTipo !== models.Usuario.TIPOS_USUARIO.ADM_ESPACO) {
       return res
@@ -523,31 +518,29 @@ export async function checkoutConvidado(req, res) {
         .json({ error: `Check-out já realizado para este convidado em ${convidado.checkout_at}.` });
     }
 
-     const webhookUrl =
-        'https://webhook.4growthbr.space/webhook/730bdcaf-8066-410c-a12c-1304b1bc65b0'; // URL CheckOut
-      try {
-        const payloadWebhook = {
-          nomeCliente: convidado.nome_convidado,
-          emailCliente: convidado.emailCliente,
-          telefoneCliente: convidado.telefoneCliente,
+    const webhookUrl =
+      'https://webhook.4growthbr.space/webhook/730bdcaf-8066-410c-a12c-1304b1bc65b0'; // URL CheckOut
+    try {
+      const payloadWebhook = {
+        nomeCliente: convidado.nome_convidado,
+        emailCliente: convidado.emailCliente,
+        telefoneCliente: convidado.telefoneCliente,
 
-          mensagem: `Check-out feito ${convidado.checkin_at}.`,
-        };
+        mensagem: `Check-out feito ${convidado.checkin_at}.`
+      };
 
-        
-        console.log('Enviando dados para o webhook n8n:', payloadWebhook);
+      // eslint-disable-next-line no-console
+      console.log('Enviando dados para o webhook n8n:', payloadWebhook);
 
-        axios.post(webhookUrl, payloadWebhook).catch((webhookError) => {
-          console.error(
-            'Erro secundário ao enviar o webhook para n8n:',
-            webhookError.response ? webhookError.response.data : webhookError.message
-          );
-        });
-      } catch (webhookError) {
-        console.error('Erro ao tentar disparar o webhook para n8n:', webhookError.message);
-      }
-
-
+      axios.post(webhookUrl, payloadWebhook).catch((webhookError) => {
+        console.error(
+          'Erro secundário ao enviar o webhook para n8n:',
+          webhookError.response ? webhookError.response.data : webhookError.message
+        );
+      });
+    } catch (webhookError) {
+      console.error('Erro ao tentar disparar o webhook para n8n:', webhookError.message);
+    }
 
     convidado.checkout_at = new Date();
     await convidado.save();

--- a/server/src/middleware/validarReqAuth.js
+++ b/server/src/middleware/validarReqAuth.js
@@ -88,19 +88,20 @@ export function verificarTokenJWT(req, res, next) {
 
 export function permitirApenas(...tiposPermitidos) {
   return (req, res, next) => {
-  
     const { usuarioTipo } = req;
 
     if (!usuarioTipo) {
-      
-      return res.status(401).json({ error: "Informações de usuário não encontradas. Falha na autenticação." });
+      return res
+        .status(401)
+        .json({ error: 'Informações de usuário não encontradas. Falha na autenticação.' });
     }
 
     if (tiposPermitidos.includes(usuarioTipo)) {
-            return next();
+      return next();
     } else {
-      
-      return res.status(403).json({ error: "Acesso negado. Você não tem permissão para realizar esta ação." });
+      return res
+        .status(403)
+        .json({ error: 'Acesso negado. Você não tem permissão para realizar esta ação.' });
     }
   };
 }

--- a/server/src/models/ConvidadoFesta.js
+++ b/server/src/models/ConvidadoFesta.js
@@ -84,7 +84,7 @@ ConvidadoFesta.init(
     },
     nome_acompanhante: {
       type: DataTypes.STRING,
-      allowNull: true,
+      allowNull: true
     },
     telefone_acompanhante: {
       type: DataTypes.STRING(25),

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -10,7 +10,6 @@ router.post('/register/convidado', verificarTokenJWT ,permitirApenas(models.Usua
 router.post('/register/admEspaco', verificarTokenJWT, permitirApenas(models.Usuario.TIPOS_USUARIO.ADM_ESPACO) ,validarRegistro, authController.registrarAdmEspaco);
 
 router.post('/register/admFesta', validarRegistro, authController.registrarAdmFesta);
-router.post('/register/admEspaco', validarRegistro, authController.registrarAdmEspaco);
 
 router.post('/login', validarLogin, authController.login);
 

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -1,13 +1,30 @@
 import express from 'express';
 import * as authController from '../controllers/authController.js';
-import { validarLogin, validarRegistro, permitirApenas, verificarTokenJWT } from '../middleware/validarReqAuth.js';
+import {
+  validarLogin,
+  validarRegistro,
+  permitirApenas,
+  verificarTokenJWT
+} from '../middleware/validarReqAuth.js';
 import models from '../models/index.js';
 
 const router = express.Router();
 
-router.post('/register/convidado', verificarTokenJWT ,permitirApenas(models.Usuario.TIPOS_USUARIO.ADM_ESPACO),validarRegistro, authController.registrarConvidado);
+router.post(
+  '/register/convidado',
+  verificarTokenJWT,
+  permitirApenas(models.Usuario.TIPOS_USUARIO.ADM_ESPACO),
+  validarRegistro,
+  authController.registrarConvidado
+);
 
-router.post('/register/admEspaco', verificarTokenJWT, permitirApenas(models.Usuario.TIPOS_USUARIO.ADM_ESPACO) ,validarRegistro, authController.registrarAdmEspaco);
+router.post(
+  '/register/admEspaco',
+  verificarTokenJWT,
+  permitirApenas(models.Usuario.TIPOS_USUARIO.ADM_ESPACO),
+  validarRegistro,
+  authController.registrarAdmEspaco
+);
 
 router.post('/register/admFesta', validarRegistro, authController.registrarAdmFesta);
 

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,36 +1,38 @@
+// server/src/server.js
 import 'dotenv/config';
-
 import express from 'express';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 import _models, { sequelize } from './models/index.js';
-
 import authRoutes from './routes/authRoutes.js';
 import festaRoutes from './routes/festaRoutes.js';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const app = express();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 3001;
 
 app.use(cors());
 app.use(express.json());
 
-app.use('/auth', authRoutes);
-app.use('/festa', festaRoutes);
+app.use(express.static(path.join(__dirname, '../../client/dist')));
 
-// Rota de teste
-app.get('/', (_req, res) => {
-  res.send(`API Rodando! Olá, mundo! Ambiente: ${process.env.NODE_ENV || 'desenvolvimento'}`);
+app.use('/api/auth', authRoutes);
+app.use('/api/festa', festaRoutes);
+
+app.get('/*splat', (_req, res) => {
+  res.sendFile(path.join(__dirname, '../../client/dist', 'index.html'));
 });
 
 async function LigarServidor() {
   try {
     await sequelize.authenticate();
-
-    // eslint-disable-next-line no-console
     console.log('Conexão com o MySQL estabelecida com sucesso.');
 
     app.listen(port, () => {
-      // eslint-disable-next-line no-console
       console.log(`Servidor rodando na porta ${port} em http://localhost:${port}`);
     });
   } catch (error) {

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -30,9 +30,11 @@ app.get('/*splat', (_req, res) => {
 async function LigarServidor() {
   try {
     await sequelize.authenticate();
+    // eslint-disable-next-line no-console
     console.log('Conexão com o MySQL estabelecida com sucesso.');
 
     app.listen(port, () => {
+      // eslint-disable-next-line no-console
       console.log(`Servidor rodando na porta ${port} em http://localhost:${port}`);
     });
   } catch (error) {


### PR DESCRIPTION
This pull request refactors the application to enable a unified deployment model where the Node.js/Express server serves both the API and the frontend client application.

This change simplifies the deployment architecture and resolves CORS issues in production.

#### **Changes Implemented:**

* **Server (`server.js`):**
    * All API routes are now prefixed with `/api`.
    * The server is configured to serve the static build files from the client (`client/dist`).
    * A catch-all route (`/*splat`) has been added to correctly handle client-side routing with React Router.

* **Client (`api.ts` & `vite.config.ts`):**
    * The client's Axios instance now targets the `/api` prefix.
    * A proxy has been added to the Vite development server to ensure a smooth local development experience by forwarding API requests to the backend.

* **Code Quality:**
    * Fixed all outstanding linting errors and warnings.
    * Removed a duplicate route from `authRoutes.js`.

#### **Testing:**

This has been tested locally using `yarn dev`, and the application runs correctly with the frontend communicating with the backend via the Vite proxy.