### PR TITLE
feat(events): Move time fields to draft creation form

### DIFF
--- a/client/src/components/events/ContractedDetailsSection.tsx
+++ b/client/src/components/events/ContractedDetailsSection.tsx
@@ -80,6 +80,34 @@ export function ContractedDetailsSection({ form }: ContractedDetailsSectionProps
             </FormItem>
           )}
         />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+          <FormField
+            control={form.control}
+            name="startTime"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Horário de Início</FormLabel>
+                <FormControl>
+                  <Input type="time" {...field} value={field.value ?? ''} disabled />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="endTime"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Horário de Término</FormLabel>
+                <FormControl>
+                  <Input type="time" {...field} value={field.value ?? ''} disabled />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
         <FormField
           control={form.control}
           name="packageType"

--- a/client/src/components/events/PersonalizePartySection.tsx
+++ b/client/src/components/events/PersonalizePartySection.tsx
@@ -29,46 +29,6 @@ export function PersonalizePartySection({ form }: PersonalizePartySectionProps) 
     <div>
       <h3 className="text-lg font-semibold mb-4 border-b pb-2">Personalize Sua Festa</h3>
       <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <FormField
-            control={form.control}
-            name="startTime"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Horário de Início</FormLabel>
-                <FormControl>
-                  <Input
-                    type="time"
-                    {...field}
-                    value={field.value ?? ''}
-                    className="focus:border-primary focus:ring-2 focus:ring-primary/30"
-                  />
-                </FormControl>
-                <FormDescription className="text-left">Formato HH:MM (ex: 14:00)</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="endTime"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Horário de Término</FormLabel>
-                <FormControl>
-                  <Input
-                    type="time"
-                    {...field}
-                    value={field.value ?? ''}
-                    className="focus:border-primary focus:ring-2 focus:ring-primary/30"
-                  />
-                </FormControl>
-                <FormDescription className="text-left">Formato HH:MM (ex: 18:00)</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
         <FormField
           control={form.control}
           name="birthdayPersonName"

--- a/client/src/pages/events/CreateDraftEventPage.tsx
+++ b/client/src/pages/events/CreateDraftEventPage.tsx
@@ -43,6 +43,8 @@ function CreateDraftEventPage() {
       organizerPhone: '',
       partyName: '',
       partyDate: new Date(),
+      startTime: '14:00',
+      endTime: '18:00',
       packageType: 'KIDS',
       contractedChildren: 0,
       contractedAdults: 0,
@@ -64,6 +66,8 @@ function CreateDraftEventPage() {
       dadosFesta: {
         nome_festa: values.partyName,
         data_festa: format(values.partyDate, 'yyyy-MM-dd'),
+        horario_inicio: values.startTime,
+        horario_fim: values.endTime,
         pacote_escolhido: values.packageType,
         numero_criancas_contratado: values.contractedChildren,
         numero_adultos_contratado: values.contractedAdults,
@@ -203,6 +207,34 @@ function CreateDraftEventPage() {
                       </FormItem>
                     )}
                   />
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6">
+                    <FormField
+                      control={form.control}
+                      name="startTime"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Horário de Início</FormLabel>
+                          <FormControl>
+                            <Input type="time" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="endTime"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Horário de Término</FormLabel>
+                          <FormControl>
+                            <Input type="time" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </div>
                   <FormField
                     control={form.control}
                     name="packageType"

--- a/client/src/schemas/eventSchemas.ts
+++ b/client/src/schemas/eventSchemas.ts
@@ -1,5 +1,9 @@
 import * as z from 'zod'
 
+const timeStringSchema = z
+  .string()
+  .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
+
 /**
  * @file Contém os schemas de validação Zod para os formulários de Festa/Evento.
  */
@@ -14,6 +18,8 @@ export const createDraftFormSchema = z.object({
   organizerPhone: z.string().min(10, 'Telefone do contratante é obrigatório (com DDD).'),
   partyName: z.string().min(1, 'Um nome para a festa é obrigatório.'),
   partyDate: z.date({ required_error: 'Data da festa é obrigatória.' }),
+  startTime: timeStringSchema,
+  endTime: timeStringSchema,
   packageType: z.enum(
     ['KIDS', 'KIDS_MAIS_PARK', 'PLAY', 'PLAY_MAIS_PARK', 'SUPER_FESTA_COMPLETA'],
     { required_error: 'Você precisa selecionar um tipo de pacote.' },
@@ -24,16 +30,6 @@ export const createDraftFormSchema = z.object({
 
 // Schema para a página de detalhes completos, que estende o rascunho.
 export const completeDetailsSchema = createDraftFormSchema.extend({
-  startTime: z
-    .string()
-    .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
-    .optional()
-    .or(z.literal('')),
-  endTime: z
-    .string()
-    .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
-    .optional()
-    .or(z.literal('')),
   description: z.string().optional().or(z.literal('')),
   birthdayPersonName: z.string().min(1, 'Nome do aniversariante é obrigatório.'),
   birthdayPersonAge: z.coerce.number().int().positive('Idade inválida.').optional().nullable(),


### PR DESCRIPTION
Moves the start and end time fields from the "complete details" form to the initial "create draft" form.

This change ensures that the party's schedule is defined by the Staff at the time of the contract, centralizing essential information from the beginning of the flow. The organizer can now only view the contracted times, not edit them.

- Updated `createDraftFormSchema` to include `startTime` and `endTime` validations.
- Removed time fields from `completeDetailsSchema`.
- Added time input fields to `CreateDraftEventPage.tsx` and included them in the creation payload.
- Removed time input fields from `PersonalizePartySection.tsx`.
- Added disabled time input fields to `ContractedDetailsSection.tsx` for display purposes.