### PR TITLE
fix(guests): Add scroll to guest management modal

### DIFF
--- a/client/src/pages/guests/GuestManagementPage.tsx
+++ b/client/src/pages/guests/GuestManagementPage.tsx
@@ -179,7 +179,7 @@ function GuestManagementPage() {
               Adicionar Convidados
             </Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-[600px]">
+          <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
             <DialogHeader>
               <DialogTitle>Adicionar Novo Convidado</DialogTitle>
               <DialogDescription>
@@ -192,7 +192,7 @@ function GuestManagementPage() {
       </header>
 
       <Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
-        <DialogContent className="sm:max-w-[600px]">
+        <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Editar Convidado</DialogTitle>
             <DialogDescription>


### PR DESCRIPTION
Resolves an overflow issue where the "Add/Edit Guest" modal content could be cut off on smaller viewports, preventing access to form fields and the submit button.

This is fixed by applying `max-h-[90vh]` and `overflow-y-auto` classes to the `DialogContent` component within `GuestManagementPage.tsx`. This ensures the modal's height is limited and a scrollbar appears when the content exceeds the available space.

- Modified `DialogContent` for both "Add" and "Edit" modals in `GuestManagementPage.tsx`.