### PR TITLE
feat(forms): Standardize and validate phone numbers

### DIFF
--- a/client/src/components/forms/PhoneInput.tsx
+++ b/client/src/components/forms/PhoneInput.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react'
+
+import { Input } from '@/components/ui/input'
+import { formatPhoneNumber, unformatPhoneNumber } from '@/lib/phoneUtils'
+
+export interface PhoneInputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
+  ({ onChange, ...props }, ref) => {
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const rawValue = unformatPhoneNumber(e.target.value)
+      const formattedValue = formatPhoneNumber(rawValue)
+
+      e.target.value = formattedValue
+
+      if (onChange) {
+        onChange(e)
+      }
+    }
+
+    return <Input {...props} ref={ref} onChange={handleInputChange} type="tel" maxLength={19} />
+  },
+)
+PhoneInput.displayName = 'PhoneInput'
+
+export { PhoneInput }

--- a/client/src/components/guests/AddGuestForm.tsx
+++ b/client/src/components/guests/AddGuestForm.tsx
@@ -4,6 +4,7 @@ import { ptBR } from 'date-fns/locale'
 import { CalendarIcon, Loader2 } from 'lucide-react'
 import { useForm, type SubmitHandler } from 'react-hook-form'
 
+import { PhoneInput } from '@/components/forms/PhoneInput'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -128,7 +129,11 @@ export function AddGuestForm({
               <FormItem>
                 <FormLabel>Telefone do Convidado</FormLabel>
                 <FormControl>
-                  <Input placeholder="(XX) XXXXX-XXXX" {...field} className="bg-background" />
+                  <PhoneInput
+                    placeholder="+55 (XX) 9XXXX-XXXX"
+                    {...field}
+                    className="bg-background"
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -215,7 +220,11 @@ export function AddGuestForm({
                 <FormItem>
                   <FormLabel>Telefone do Responsável</FormLabel>
                   <FormControl>
-                    <Input placeholder="(XX) XXXXX-XXXX" {...field} className="bg-background" />
+                    <PhoneInput
+                      placeholder="+55 (XX) 9XXXX-XXXX"
+                      {...field}
+                      className="bg-background"
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -268,7 +277,11 @@ export function AddGuestForm({
                 <FormItem>
                   <FormLabel>Telefone do Acompanhante</FormLabel>
                   <FormControl>
-                    <Input placeholder="(XX) XXXXX-XXXX" {...field} className="bg-background" />
+                    <PhoneInput
+                      placeholder="+55 (XX) 9XXXX-XXXX"
+                      {...field}
+                      className="bg-background"
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/client/src/lib/phoneUtils.ts
+++ b/client/src/lib/phoneUtils.ts
@@ -1,0 +1,75 @@
+import * as z from 'zod'
+
+/**
+ * Remove todos os caracteres não numéricos de uma string.
+ * @param phone - A string do telefone (formatada ou não).
+ * @returns Apenas os dígitos do número.
+ */
+export const unformatPhoneNumber = (phone: string | undefined | null): string => {
+  if (!phone) return ''
+  return phone.replace(/\D/g, '')
+}
+
+/**
+ * Formata um número de telefone no padrão brasileiro.
+ * Ex: 5579999999999 -> +55 (79) 99999-9999
+ * @param value - O número de telefone (apenas dígitos).
+ * @returns O número formatado.
+ */
+export const formatPhoneNumber = (value: string): string => {
+  const digitsOnly = unformatPhoneNumber(value)
+
+  if (digitsOnly.length === 0) {
+    return ''
+  }
+
+  let formatted = `+${digitsOnly.substring(0, 2)}` // +55
+
+  if (digitsOnly.length > 2) {
+    formatted += ` (${digitsOnly.substring(2, 4)}` // +55 (79
+  }
+
+  if (digitsOnly.length > 4) {
+    const part = digitsOnly.substring(4, 9)
+    if (part.length > 0) formatted += `) ${part}` // +55 (79) 99999
+  }
+
+  if (digitsOnly.length > 9) {
+    const part = digitsOnly.substring(9, 13)
+    if (part.length > 0) formatted += `-${part}` // +55 (79) 99999-9999
+  }
+
+  return formatted
+}
+
+/**
+ * Schema de validação Zod para números de telefone brasileiros.
+ * Valida o formato, código de país, DDD e a presença do nono dígito.
+ */
+export const brazilianPhoneSchema = z
+  .string()
+  .transform((value) => unformatPhoneNumber(value))
+  .refine((value) => value.length === 13, {
+    message: 'O telefone deve ter 13 dígitos (código do país + DDD + número).',
+  })
+  .refine((value) => value.startsWith('55'), {
+    message: 'O número deve começar com o código do país 55.',
+  })
+  .refine(
+    (value) => {
+      const ddd = parseInt(value.substring(2, 4), 10)
+      // Lista simplificada de DDDs válidos no Brasil.
+      const validDDDs = [
+        11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 24, 27, 28, 31, 32, 33, 34, 35, 37, 38, 41, 42,
+        43, 44, 45, 46, 47, 48, 49, 51, 53, 54, 55, 61, 62, 63, 64, 65, 66, 67, 68, 69, 71, 73, 74,
+        75, 77, 79, 81, 82, 83, 84, 85, 86, 87, 88, 89, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+      ]
+      return validDDDs.includes(ddd)
+    },
+    {
+      message: 'DDD inválido.',
+    },
+  )
+  .refine((value) => value.substring(4, 5) === '9', {
+    message: 'O número de celular deve conter o nono dígito.',
+  })

--- a/client/src/pages/events/CreateDraftEventPage.tsx
+++ b/client/src/pages/events/CreateDraftEventPage.tsx
@@ -6,6 +6,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 
+import { PhoneInput } from '@/components/forms/PhoneInput'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -137,10 +138,11 @@ function CreateDraftEventPage() {
                       <FormItem>
                         <FormLabel>WhatsApp do Contratante</FormLabel>
                         <FormControl>
-                          <Input placeholder="(XX) XXXXX-XXXX" {...field} />
+                          {/* O uso do componente não muda */}
+                          <PhoneInput placeholder="+55 (XX) 9XXXX-XXXX" {...field} />
                         </FormControl>
                         <FormDescription className="text-left">
-                          Usado para enviar o link de acesso.
+                          O número deve incluir 55 e o DDD.
                         </FormDescription>
                         <FormMessage />
                       </FormItem>

--- a/client/src/schemas/eventSchemas.ts
+++ b/client/src/schemas/eventSchemas.ts
@@ -1,5 +1,7 @@
 import * as z from 'zod'
 
+import { brazilianPhoneSchema } from '@/lib/phoneUtils'
+
 const timeStringSchema = z
   .string()
   .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
@@ -15,7 +17,7 @@ export const createDraftFormSchema = z.object({
     .string()
     .min(1, 'Email do contratante é obrigatório.')
     .email('Formato de email inválido.'),
-  organizerPhone: z.string().min(10, 'Telefone do contratante é obrigatório (com DDD).'),
+  organizerPhone: brazilianPhoneSchema,
   partyName: z.string().min(1, 'Um nome para a festa é obrigatório.'),
   partyDate: z.date({ required_error: 'Data da festa é obrigatória.' }),
   startTime: timeStringSchema,


### PR DESCRIPTION
Implements a centralized and robust solution for handling Brazilian phone numbers throughout the application. This ensures data consistency for backend services and webhooks while improving user experience with an auto-formatting input mask.

- Created `phoneUtils.ts` to centralize formatting logic and a reusable Zod schema (`brazilianPhoneSchema`).
- Created a new reusable `PhoneInput` component in `components/forms/` to apply a visual mask during user input.
- Updated `eventSchemas.ts` to use `brazilianPhoneSchema` for the organizer's phone number.
- Updated `guestSchemas.ts` to use `brazilianPhoneSchema` for all phone fields, with conditional validation logic.
- Integrated `PhoneInput` into `CreateDraftEventPage.tsx` and `AddGuestForm.tsx`.