### PR TITLE
fix(auth): Implement silent token validation on app load

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -35,9 +35,9 @@ import { ProtectedRoute } from '@/router/ProtectedRoute'
  * Additionally, includes a Toaster component for displaying notifications.
  */
 function App() {
-  const { user } = useAuth()
+  const { isLoading } = useAuth()
 
-  if (user === undefined) {
+  if (isLoading) {
     return <SplashScreen />
   }
 

--- a/client/src/contexts/authContextCore.ts
+++ b/client/src/contexts/authContextCore.ts
@@ -15,6 +15,7 @@ export interface AuthState {
   isAuthenticated: boolean
   user: AuthenticatedUser | null | undefined
   token?: string | null
+  isLoading: boolean
 }
 
 export interface AuthContextType extends AuthState {

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: `${import.meta.env.VITE_API_BASE_URL || ''}/api`,
+  baseURL: '/api',
 })
 
 api.interceptors.request.use(

--- a/server/src/controllers/authController.js
+++ b/server/src/controllers/authController.js
@@ -143,6 +143,25 @@ export async function registrarAdmFesta(req, res) {
   }
 }
 
+export async function validarSessao(req, res) {
+  try {
+    const usuario = await models.Usuario.findByPk(req.usuarioId, {
+      attributes: { exclude: ['senha', 'redefineSenhaToken', 'redefineSenhaExpiracao'] }
+    });
+
+    if (!usuario) {
+      return res.status(404).json({ error: 'Usuário do token não encontrado.' });
+    }
+
+    return res.status(200).json({ usuario });
+
+  } catch (error) {
+    console.error('Erro ao validar sessão:', error);
+    return res.status(500).json({ error: 'Erro interno ao validar sessão.' });
+  }
+}
+
+
 export async function definirSenha(req, res) {
   try {
     const { token, novaSenha } = req.body;

--- a/server/src/routes/authRoutes.js
+++ b/server/src/routes/authRoutes.js
@@ -30,6 +30,8 @@ router.post('/register/admFesta', validarRegistro, authController.registrarAdmFe
 
 router.post('/login', validarLogin, authController.login);
 
+router.get('/me', verificarTokenJWT, authController.validarSessao);
+
 router.post('/definir-senha', authController.definirSenha);
 
 export default router;


### PR DESCRIPTION
Resolves an issue where the application would enter an unresponsive state after the JWT token expired. This fix introduces a silent validation mechanism that verifies the session with the backend upon application startup.

This new flow prevents UI "flickers" by showing a splash screen during the check and ensures the user is gracefully redirected to the login page if their session is no longer valid, improving both stability and user experience.

- Added a new `GET /api/auth/me` endpoint to the backend for session validation.
- Refactored `AuthProvider` to include a loading state and call the `/me` endpoint to validate the session before rendering protected routes.
- Updated `App.tsx` to display the `SplashScreen` during this initial validation check.
- Changed the Axios `baseURL` in `api.ts` to a relative path (`/api`) to simplify development and testing across different devices via the Vite proxy.