### PR TITLE
fix(infra): Correct Docker Compose configurations for deploy and local testing

### DIFF
--- a/infra/docker-compose.local.yml
+++ b/infra/docker-compose.local.yml
@@ -7,4 +7,4 @@ services:
     env_file:
       - ../.env
     ports:
-      - "3001:3001"
+      - "3002:3001"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
 secrets:
   checkfacil_env_file:
-    file: ./config/.env
+    file: ../config/.env
 
 networks:
   4GTNET:


### PR DESCRIPTION
#### Visão Geral

Este PR aplica duas pequenas, mas cruciais, correções nos nossos arquivos `docker-compose` para garantir que o fluxo de deploy funcione em produção e que o teste local seja livre de conflitos.

#### Correções Implementadas

1.  **Caminho do Segredo no Deploy de Produção (`docker-compose.yml`):**
    -   O caminho para o arquivo de segredos foi corrigido de `./config/.env` para `../config/.env`.
    -   **Motivo:** Isso garante que o Docker Swarm localize o arquivo `.env` corretamente a partir da raiz do projeto, em vez de procurá-lo dentro da pasta `infra/`.

2.  **Mapeamento de Porta no Teste Local (`docker-compose.local.yml`):**
    -   A porta exposta foi alterada de `3001:3001` para `3002:3001`.
    -   **Motivo:** Isso previne conflitos de porta quando um desenvolvedor estiver rodando o ambiente de desenvolvimento (`yarn dev` na porta 3001) e o ambiente de teste Docker (`yarn docker:up`) simultaneamente.

Estas alterações finalizam a configuração da nossa nova infraestrutura como código, tornando-a robusta e pronta para uso.