### PR TITLE
feat(guest-flow): improve group submission, routes, and step headers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -56,7 +56,7 @@ function App() {
           <Route path="/organizer/choosePassword/:token" element={<SetPasswordPage />} />
 
           <Route element={<PublicLayout />}>
-            <Route path="/guest/flow-selection/:eventId" element={<FlowSelectionPage />} />
+            <Route path="/guest/:eventId/flow-selection" element={<FlowSelectionPage />} />
             <Route path="/guest/:eventId/confirm-adult" element={<ConfirmAdultPage />} />
             <Route
               path="/guest/:eventId/confirm-responsible"

--- a/client/src/components/common/StepHeader.tsx
+++ b/client/src/components/common/StepHeader.tsx
@@ -1,0 +1,55 @@
+import { ArrowLeft } from 'lucide-react'
+
+
+import { Button } from '@/components/ui/button'
+import {
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+
+import type { ReactNode } from 'react'
+
+interface StepHeaderProps {
+  title: string
+  description: string
+  onBack?: () => void
+  icon?: ReactNode
+}
+
+export function StepHeader({
+  title,
+  description,
+  onBack,
+  icon, 
+}: StepHeaderProps) {  
+  return (
+    <>
+      <CardHeader>
+        <div className="flex items-start gap-4">
+          {onBack && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-9 w-9 shrink-0"
+              onClick={onBack}
+              aria-label="Voltar"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+          )}
+          <div className="flex-1">
+            <div className="flex items-center gap-3">
+              {icon && <div className="text-primary">{icon}</div>}
+              <CardTitle className="text-xl md:text-2xl">{title}</CardTitle>
+            </div>
+            <CardDescription className="mt-1">{description}</CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <Separator className="mb-6" />
+    </>
+  )
+}

--- a/client/src/components/events/ShareInviteLink.tsx
+++ b/client/src/components/events/ShareInviteLink.tsx
@@ -41,7 +41,7 @@ export function ShareInviteLink({ eventId }: ShareInviteLinkProps) {
     enabled: !!eventId,
   })
 
-  const inviteLink = `${window.location.origin}/guest/flow-selection/${eventId}`
+  const inviteLink = `${window.location.origin}/guest/${eventId}/flow-selection`
   const partyName = eventData?.nome_festa || 'nossa festa'
   const inviteImageURL = eventData?.link_convite
 

--- a/client/src/pages/guest/ConfirmChildrenFlowPage.tsx
+++ b/client/src/pages/guest/ConfirmChildrenFlowPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { toast } from 'sonner'
+import { useNavigate } from 'react-router-dom'
 
 import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useGuestConfirmationFlow } from '@/hooks/useGuestConfirmationFlow'
@@ -17,6 +17,8 @@ export type ChildNeedingCompanion = {
 }
 
 export default function ConfirmChildrenFlowPage() {
+  const navigate = useNavigate()
+
   const {
     currentStep,
     eventData,
@@ -25,7 +27,7 @@ export default function ConfirmChildrenFlowPage() {
     childrenNeedingCompanion,
     handleNextFromResponsible,
     handleNextFromChildren,
-    submitGuests,
+    handleGroupSubmit,
     setCurrentStep,
   } = useGuestConfirmationFlow()
 
@@ -44,6 +46,7 @@ export default function ConfirmChildrenFlowPage() {
         <ConfirmResponsibleStep
           onNext={handleNextFromResponsible}
           initialData={flowState.responsible}
+          onBack={() => navigate(-1)} 
         />
       )}
       {currentStep === 'CHILDREN' && (
@@ -55,7 +58,7 @@ export default function ConfirmChildrenFlowPage() {
       )}
       {currentStep === 'COMPANION' && (
         <CompanionStep
-          onFinalSubmit={(data) => submitGuests(data)}
+          onFinalSubmit={(data) => handleGroupSubmit(data, undefined)}
           onBack={() => setCurrentStep('CHILDREN')}
           childrenNeedingCompanion={childrenNeedingCompanion}
           isSubmitting={isPending}
@@ -64,18 +67,7 @@ export default function ConfirmChildrenFlowPage() {
       )}
       {currentStep === 'FINAL_CONFIRMATION' && (
         <FinalConfirmationStep
-          onSubmit={(isAttending) => {
-            const payload = {
-              responsible: flowState.responsible,
-              children: flowState.children,
-              isAttending,
-            }
-            if (payload.responsible && payload.children) {
-              submitGuests(payload)
-            } else {
-              toast.error('Erro: dados de confirmação de presença inválidos')
-            }
-          }}
+          onSubmit={(isAttending) => handleGroupSubmit(null, isAttending)}
           onBack={() => setCurrentStep('CHILDREN')}
           childrenData={flowState.children!}
           isSubmitting={isPending}

--- a/client/src/pages/guest/steps/AddChildrenStep.tsx
+++ b/client/src/pages/guest/steps/AddChildrenStep.tsx
@@ -5,9 +5,10 @@ import { ArrowRight, CalendarIcon, Loader2, PlusCircle, Trash2 } from 'lucide-re
 import { useFieldArray, useForm } from 'react-hook-form'
 import * as z from 'zod'
 
+import { StepHeader } from '@/components/common/StepHeader'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
@@ -65,10 +66,11 @@ export function AddChildrenStep({ onNext, onBack, initialData }: AddChildrenStep
 
   return (
     <Card className="w-full max-w-2xl">
-      <CardHeader>
-        <CardTitle className="text-2xl">Adicionar Crianças</CardTitle>
-        <CardDescription>Informe os dados de cada criança que irá à festa.</CardDescription>
-      </CardHeader>
+      <StepHeader
+        title="Adicionar Crianças"
+        description="Informe os dados de cada criança que irá à festa."
+        onBack={onBack}
+      />
       <CardContent>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onNext)} className="space-y-6">

--- a/client/src/pages/guest/steps/CompanionStep.tsx
+++ b/client/src/pages/guest/steps/CompanionStep.tsx
@@ -1,11 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { ArrowRight, Info, Loader2 } from 'lucide-react'
+import { ArrowRight, Loader2 } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import * as z from 'zod'
 
+import { StepHeader } from '@/components/common/StepHeader'
 import { PhoneInput } from '@/components/forms/PhoneInput'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import { Checkbox } from '@/components/ui/checkbox'
 import {
   Form,
@@ -77,28 +78,21 @@ export function CompanionStep({
 
   return (
     <Card className="w-full max-w-lg">
-      <CardHeader>
-        <CardTitle>Acompanhante Obrigatório</CardTitle>
-        <CardDescription>
-          Para a segurança de{' '}
-          <span className="font-semibold text-primary">
-            {formatNameList(childrenNeedingCompanion.map((c) => c.name))}
-          </span>
-          , confirme quem irá acompanhá-las.
-        </CardDescription>
-      </CardHeader>
+<StepHeader
+        title="Acompanhante Obrigatório"
+        description="Para a segurança das crianças, confirme quem irá acompanhá-las."
+        onBack={onBack}
+      />
+      
       <CardContent>
-        <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-900/50 dark:bg-blue-900/20">
-          <h4 className="flex items-center font-semibold text-blue-800 dark:text-blue-200">
-            <Info className="mr-2 h-5 w-5" /> Por que isso é necessário?
-          </h4>
-          <ul className="mt-2 list-disc pl-5 text-sm text-blue-700 dark:text-blue-300">
-            {childrenNeedingCompanion.map((child) => (
-              <li key={child.name}>
-                <span className="font-medium">{child.name}</span>: {child.reason}
-              </li>
-            ))}
-          </ul>
+<div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800 dark:border-blue-900/50 dark:bg-blue-900/20">
+          <p>
+            É necessário um acompanhante para{' '}
+            <span className="font-semibold text-primary">
+              {formatNameList(childrenNeedingCompanion.map((c) => c.name))}
+            </span>
+            , pois são crianças atípicas ou menores de 6 anos.
+          </p>
         </div>
 
         <Form {...form}>

--- a/client/src/pages/guest/steps/ConfirmResponsibleStep.tsx
+++ b/client/src/pages/guest/steps/ConfirmResponsibleStep.tsx
@@ -3,9 +3,10 @@ import { ArrowRight, Loader2 } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import * as z from 'zod'
 
+import { StepHeader } from '@/components/common/StepHeader'
 import { PhoneInput } from '@/components/forms/PhoneInput'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent } from '@/components/ui/card'
 import {
   Form,
   FormControl,
@@ -26,10 +27,11 @@ export type ResponsibleStepValues = z.infer<typeof responsibleStepSchema>
 
 interface ConfirmResponsibleStepProps {
   onNext: (data: ResponsibleStepValues) => void
-  initialData?: ResponsibleStepValues | null
+  initialData?: ResponsibleStepValues | null,
+  onBack: () => void
 }
 
-export function ConfirmResponsibleStep({ onNext, initialData }: ConfirmResponsibleStepProps) {
+export function ConfirmResponsibleStep({ onNext, initialData, onBack }: ConfirmResponsibleStepProps) {
   const form = useForm<ResponsibleStepValues>({
     resolver: zodResolver(responsibleStepSchema),
     defaultValues: initialData || { responsibleName: '', responsiblePhone: '' },
@@ -39,12 +41,11 @@ export function ConfirmResponsibleStep({ onNext, initialData }: ConfirmResponsib
 
   return (
     <Card className="w-full max-w-lg">
-      <CardHeader>
-        <CardTitle className="text-2xl">Contato do Responsável</CardTitle>
-        <CardDescription>
-          Para a segurança das crianças, precisamos de um contato de emergência.
-        </CardDescription>
-      </CardHeader>
+      <StepHeader
+        title="Contato do Responsável"
+        description="Para a segurança das crianças, precisamos de um contato de emergência."
+        onBack={onBack}
+      />
       <CardContent>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onNext)} className="space-y-6">

--- a/client/src/pages/guest/steps/FinalConfirmationStep.tsx
+++ b/client/src/pages/guest/steps/FinalConfirmationStep.tsx
@@ -1,10 +1,10 @@
 import { Loader2, PartyPopper } from 'lucide-react'
 import { useState } from 'react'
 
+import { StepHeader } from '@/components/common/StepHeader'
 import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-
-import { type AddChildrenStepValues } from './AddChildrenStep'
+import { Card, CardContent } from '@/components/ui/card'
+import { type AddChildrenStepValues } from '@/pages/guest/steps/AddChildrenStep'
 
 interface FinalConfirmationStepProps {
   onSubmit: (isAttending: boolean) => void
@@ -35,14 +35,13 @@ export function FinalConfirmationStep({
 
   return (
     <Card className="w-full max-w-lg">
-      <CardHeader className="text-center">
-        <PartyPopper className="mx-auto h-12 w-12 text-primary" />
-        <CardTitle className="text-2xl">Quase lá!</CardTitle>
-        <CardDescription>
-          A presença de <span className="font-semibold">{childrenNames}</span> está pronta para ser
-          confirmada. Só mais uma pergunta:
-        </CardDescription>
-      </CardHeader>
+<StepHeader
+        title="Quase lá!"
+        description={`A presença de ${childrenNames} está pronta para ser confirmada. Só mais uma pergunta:`}
+        onBack={onBack}
+        // Passe o ícone com um tamanho menor para o alinhamento
+        icon={<PartyPopper className="h-8 w-8" />}
+      />
       <CardContent className="space-y-4">
         <p className="text-center font-semibold">Você (o responsável) também irá à festa?</p>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/server/src/controllers/festaController.js
+++ b/server/src/controllers/festaController.js
@@ -311,31 +311,32 @@ export async function registrarGrupoConvidados(req, res) {
     const criancasSalvas = [];
 
     for (const convidado of convidados) {
-      if (!convidado.nome || !convidado.tipo_convidado) {
+      if (!convidado.nome_convidado || !convidado.tipo_convidado) { 
         await transaction.rollback();
         return res.status(400).json({
-          error: 'Cada convidado deve ter nome e tipo_convidado.'
+            error: 'Cada convidado deve ter nome_convidado e tipo_convidado.' // Mensagem atualizada
         });
-      }
+    }
 
-      // Cria o convidado
-      const novoConvidado = await models.ConvidadoFesta.create(
+    // 2. CORRIGIR OS CAMPOS NA CRIAÇÃO DO REGISTRO
+    const novoConvidado = await models.ConvidadoFesta.create(
         {
-          id_festa: idFesta,
-          nome_convidado: convidado.nome,
-          tipo_convidado: convidado.tipo_convidado,
-          nascimento_convidado: convidado.dataNascimento || null,
-          idade_convidado: convidado.dataNascimento
-            ? calcularIdade(convidado.dataNascimento)
-            : null,
-          e_crianca_atipica: convidado.isCriancaAtipica || false,
-          nome_responsavel_contato: contatoResponsavel.nome,
-          telefone_responsavel_contato: contatoResponsavel.telefone,
-          cadastrado_na_hora: convidado.cadastrado_na_hora || null,
-          acompanhado_por_id: convidado.acompanhado_por_id || null
+            id_festa: idFesta,
+            nome_convidado: convidado.nome_convidado,                
+            tipo_convidado: convidado.tipo_convidado,
+            nascimento_convidado: convidado.nascimento_convidado || null, 
+            idade_convidado: convidado.nascimento_convidado
+                ? calcularIdade(convidado.nascimento_convidado)
+                : null,
+            e_crianca_atipica: convidado.e_crianca_atipica || false,   
+            nome_responsavel_contato: contatoResponsavel.nome,
+            telefone_responsavel_contato: contatoResponsavel.telefone,
+            cadastrado_na_hora: convidado.cadastrado_na_hora || null,
+            acompanhado_por_id: convidado.acompanhado_por_id || null
         },
         { transaction }
-      );
+    );
+
 
       if (convidado.tipo_convidado.startsWith('CRIANCA') || convidado.e_crianca_atipica) {
         criancasSalvas.push(novoConvidado);


### PR DESCRIPTION
This PR enhances the guest confirmation flow by introducing a reusable StepHeader component, improving route patterns, and refining the group submission logic.

### Changes
- Added a new `StepHeader` component for consistent step headers across guest flow steps.
- Refactored all step pages (AddChildren, Companion, ConfirmResponsible, FinalConfirmation) to use `StepHeader` instead of inline `CardHeader`.
- Updated the guest flow route to `/guest/:eventId/flow-selection` and adjusted `ShareInviteLink` accordingly.
- Implemented `handleGroupSubmit` in `useGuestConfirmationFlow` to handle group payload submission and improved error handling.
- Added back navigation support in `ConfirmChildrenFlowPage`.
- Fixed backend `registrarGrupoConvidados` to use the correct `nome_convidado` and `nascimento_convidado` fields.

### Why
These changes provide:
- A more consistent and user-friendly UI.
- A clearer and more semantic route structure.
- A robust and maintainable group submission process.
- Correct backend field handling to match the updated payload structure.