### PR TITLE
feat: atualiza horário padrão e opções de decoração

### DIFF
--- a/client/src/pages/events/CompleteEventDetailsPage.tsx
+++ b/client/src/pages/events/CompleteEventDetailsPage.tsx
@@ -23,7 +23,7 @@ import type { UpdateEventPayload } from '@/types'
 // Tipos para os enums para garantir a tipagem correta
 type PackageType = 'KIDS' | 'KIDS_MAIS_PARK' | 'PLAY' | 'PLAY_MAIS_PARK' | 'SUPER_FESTA_COMPLETA'
 type GuestPolicy = 'PERMITIR_ANOTAR' | 'CHAMAR_ANFITRIAO'
-type LocalDecoracaoType = 'PLAY' | 'CASINHAS'
+type LocalDecoracaoType = 'PLAY' | 'CASINHAS' | 'ENTRE_CASINHAS' | 'KIDS' | 'SALAO_DE_FESTAS'
 
 // Interface para os dados da API, garantindo que o `id` e outros campos existam
 interface ApiEventData {
@@ -85,8 +85,8 @@ function EventForm({ eventData, playlists }: { eventData: ApiEventData; playlist
       packageType: eventData.pacote_escolhido,
       contractedAdults: eventData.numero_adultos_contratado || 0,
       contractedChildren: eventData.numero_criancas_contratado || 0,
-      startTime: eventData.horario_inicio ? eventData.horario_inicio.substring(0, 5) : null,
-      endTime: eventData.horario_fim ? eventData.horario_fim.substring(0, 5) : null,
+      startTime: eventData.horario_inicio ? eventData.horario_inicio.substring(0, 5) : '',
+      endTime: eventData.horario_fim ? eventData.horario_fim.substring(0, 5) : '',
       birthdayPersonName: eventData.nome_aniversariante || '',
       birthdayPersonAge: eventData.idade_aniversariante || undefined,
       partyTheme: eventData.tema_festa || '',

--- a/client/src/pages/events/CreateDraftEventPage.tsx
+++ b/client/src/pages/events/CreateDraftEventPage.tsx
@@ -56,8 +56,8 @@ function CreateDraftEventPage() {
       organizerPhone: '',
       partyName: '',
       partyDate: new Date(),
-      startTime: '14:00',
-      endTime: '18:00',
+      startTime: '14:00', // Valor padrão obrigatório
+      endTime: '17:00',   // Valor padrão obrigatório
       packageType: 'KIDS',
       contractedChildren: 0,
       contractedAdults: 0,

--- a/client/src/pages/events/FornecedorSection.tsx
+++ b/client/src/pages/events/FornecedorSection.tsx
@@ -64,8 +64,11 @@ export function FornecedorSection({ form }: FornecedorSectionProps) {
                   <SelectValue placeholder="Selecione o local" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="PLAY">PLAY</SelectItem>
-                  <SelectItem value="CASINHAS">CASINHAS</SelectItem>
+                  <SelectItem value="PLAY">Play</SelectItem>
+                  <SelectItem value="CASINHAS">Casinhas</SelectItem>
+                  <SelectItem value="ENTRE_CASINHAS">Entre casinhas</SelectItem>
+                  <SelectItem value="KIDS">Kids</SelectItem>
+                  <SelectItem value="SALAO_DE_FESTAS">Salão de festas</SelectItem>
                 </SelectContent>
               </Select>
             )}

--- a/client/src/schemas/eventSchemas.ts
+++ b/client/src/schemas/eventSchemas.ts
@@ -5,8 +5,7 @@ import { brazilianPhoneSchema } from '@/lib/phoneUtils'
 const timeStringSchema = z
   .string()
   .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
-  .nullable()
-  .optional()
+  .min(1, 'Horário é obrigatório')
 
 export const createDraftFormSchema = z.object({
   organizerName: z.string().min(1, 'Nome do contratante é obrigatório.'),
@@ -52,7 +51,7 @@ export const completeDetailsSchema = createDraftFormSchema
     decoradorContato: z.string().optional().or(z.literal('')),
     temMaterialTerceirizado: z.boolean().default(false),
     materialTerceirizadoContato: z.string().optional().or(z.literal('')),
-    localDecoracao: z.enum(['PLAY', 'CASINHAS']).optional().or(z.literal('')),
+    localDecoracao: z.enum(['PLAY', 'CASINHAS', 'ENTRE_CASINHAS', 'KIDS', 'SALAO_DE_FESTAS']).optional().or(z.literal('')),
     buffetNome: z.string().optional().or(z.literal('')),
     buffetContato: z.string().optional().or(z.literal('')),
     bebidasFornecedorNome: z.string().optional().or(z.literal('')),

--- a/client/src/schemas/eventSchemas.ts
+++ b/client/src/schemas/eventSchemas.ts
@@ -6,6 +6,8 @@ const timeStringSchema = z
   .string()
   .regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Formato de hora inválido (HH:MM).')
   .min(1, 'Horário é obrigatório')
+  .or(z.literal(''))
+  .transform(val => val || undefined)
 
 export const createDraftFormSchema = z.object({
   organizerName: z.string().min(1, 'Nome do contratante é obrigatório.'),

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -143,7 +143,7 @@ export type UpdateEventPayload = {
   decorador_contato?: string
   tem_material_terceirizado?: boolean
   material_terceirizado_contato?: string
-  local_decoracao?: 'PLAY' | 'CASINHAS' | null
+  local_decoracao?: 'PLAY' | 'CASINHAS' | 'ENTRE_CASINHAS' | 'KIDS' | 'SALAO_DE_FESTAS' | null
   buffet_nome?: string
   buffet_contato?: string
   bebidas_fornecedor_nome?: string

--- a/server/src/models/Festa.js
+++ b/server/src/models/Festa.js
@@ -110,7 +110,7 @@ Festa.init(
       allowNull: true
     },
     local_decoracao: {
-      type: DataTypes.ENUM('PLAY', 'CASINHAS'),
+      type: DataTypes.ENUM('PLAY', 'CASINHAS', 'ENTRE_CASINHAS', 'KIDS', 'SALAO_DE_FESTAS'),
       allowNull: true
     },
     buffet_nome: {


### PR DESCRIPTION
# feat: atualiza horário padrão e opções de decoração

## Descrição
Este PR implementa as seguintes melhorias:

1. **Atualização do horário padrão**:
   - Altera o horário de término padrão das festas de 18h para 17h
   - Ajusta a validação de horários nos formulários

2. **Novas opções de local de decoração**:
   - Adiciona as seguintes opções de local de decoração:
     - Play
     - Casinhas
     - Entre casinhas
     - Kids
     - Salão de festas

3. **Melhorias técnicas**:
   - Atualiza os tipos TypeScript para refletir as novas opções
   - Ajusta os schemas de validação
   - Corrige o tratamento de campos de tempo nos formulários

## Testes
- [ ] Verificar se o horário padrão foi atualizado corretamente
- [ ] Testar todas as opções de local de decoração
- [ ] Validar o fluxo de criação/edição de eventos
